### PR TITLE
RHACM4K-412: First test: Search Saved searches

### DIFF
--- a/tests/cypress/tests/savedSearches.spec.js
+++ b/tests/cypress/tests/savedSearches.spec.js
@@ -13,7 +13,10 @@ const queryDefaultNamespaceDesc = 'this is searching that each cluster should ha
 const queryOcmaNamespaceName = 'open-cluster-management-agent search'
 const queryOcmaNamespaceDesc = 'this is searching that each cluster should have open-cluster-management-agent'
 
-describe('Search: Saved searches', function(){
+const queryOCMaEditedName = `[E2E] default namespace search - ${Date.now()}`
+const queryOcmaEditedDesc = '[Created by Search E2E automation] This is searching that each cluster should have default namespace -2'
+
+describe('RHACM4K-412 - Search: Saved searches', function(){
 
   before(function() {
     cy.login()
@@ -41,5 +44,22 @@ describe('Search: Saved searches', function(){
   it(`[P2][Sev2][${squad}] should be able to find the saved searches`, function() {
     savedSearches.getSavedSearch(queryDefaultNamespaceName)
     savedSearches.getSavedSearch(queryOcmaNamespaceName)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to edit the saved searches`, function() {
+    savedSearches.editSavedSearch(queryDefaultNamespaceName, queryOCMaEditedName, queryOcmaEditedDesc)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to find the saved searches`, function() {
+    savedSearches.getSavedSearch(queryOCMaEditedName)
+    savedSearches.getSavedSearch(queryOcmaNamespaceName)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to revert back the edited saved searches`, function() {
+    savedSearches.editSavedSearch(queryOCMaEditedName, queryDefaultNamespaceName, queryDefaultNamespaceDesc)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to share the saved searches`, function() {
+    savedSearches.shareSavedSearch(queryDefaultNamespaceName)
   })
 })

--- a/tests/cypress/views/savedSearches.js
+++ b/tests/cypress/views/savedSearches.js
@@ -48,6 +48,26 @@ export const savedSearches = {
     cy.get('.pf-c-modal-box__footer', {timeout: 20000}).contains('Save').should('exist').focus().click()
   },
 
+  editSavedSearch: (queryName, editedName, editedDesc) => {
+    searchPage.whenGoToSearchPage()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches').should('exist')
+    cy.get('.pf-c-card__header').contains(queryName).should('exist').parent().siblings().find('button').click()
+    cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Edit').click()
+    cy.get('#add-query-name').clear().type(editedName)
+    cy.get('#add-query-desc').clear().type(editedDesc)
+    cy.get('.pf-c-modal-box__footer').contains('Save').should('exist').focus().click()
+  },
+
+  shareSavedSearch: (queryName) => {
+    searchPage.whenGoToSearchPage()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches').should('exist')
+    cy.get('.pf-c-card__header').contains(queryName).should('exist').parent().siblings().find('button').click()
+    cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Share').click()
+    cy.get(".pf-c-code-editor__code").find('pre').invoke('text').then((urlText) => {
+      cy.visit(urlText.toString());
+    });
+  },
+
   getSavedSearch: (queryName) => {
     searchPage.whenGoToSearchPage()
     cy.get('.pf-c-title.pf-m-md', {timeout: 20000}).contains('Saved searches').should('exist')


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/ACM-346
https://polarion.engineering.redhat.com/polarion/#/project/RHACM4K/workitem?id=RHACM4K-412

Description:
=========
Done Prereq: create an `auto-test` namespace in the hub
Done Login to UI
Done Go to search page by clicking the search icon
Done On the search bar, enter: kind:namespace and name:auto-test
Done Verify the namespace is found
Done Click on Save icon to save this search query with name, auto-test-ns-search
Done Enter description, Automation test: saving a namespace search query. 
Done Go back to Search page, and verify the saved search is available on the dashboard under “Saved searches”
Done Verify the saved search is available on the “Saved Searches” drop down menu as well. 
Done Click on the `auto-test-ns-search` to execute the saved search, verify the result is correct
Done Navigate to the `auto-test-ns-search` under the “Saved Searches” drop down menu, and click on it. Verify the result is correct. 
Done Click the options icon for the saved search, and select Edit
Done Enter a “-2” to the name and description boxes
Done Click Save
Done Verify the name and description changes on the dashboard 
Done Undo these changes for the next tests
Done Click the options icon for the saved search, and select Share
Done Copy the link 
Done Open a new browser and paste the link, and it returns the correct result
Done Click the options icon for the saved search, and select Delete
Done Verify the saved search is deleted from the dashboard and dropdown

Signed-off-by: Sri Vignesh <sselvan@redhat.com>