### PR TITLE
Skip osImage suggestions (second attempt)

### DIFF
--- a/tests/cypress/tests/filters.spec.js
+++ b/tests/cypress/tests/filters.spec.js
@@ -74,7 +74,7 @@ filtersRegistry.createFilter('volumeName')
 // filtersRegistry.createFilter('accessMode') // Failing on canary environment
 filtersRegistry.createFilter('architecture')
 // osImage has no suggestions because values have blank spaces. Issue: https://github.com/open-cluster-management/backlog/issues/1715
-filtersRegistry.createFilter('osImage', { values: [] })
+// filtersRegistry.createFilter('osImage', { values: [] })
 filtersRegistry.createFilter('claimRef')
 filtersRegistry.createFilter('reclaimPolicy')
 filtersRegistry.createFilter('lastSchedule')


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/6057

We aren't showing suggestions with empty spaces because it causes issues.
The filter `osImage` now doesn't show any suggestions.