### PR TITLE
Filter console-ui-test clusters

### DIFF
--- a/tests/cypress/views/clusters.js
+++ b/tests/cypress/views/clusters.js
@@ -11,7 +11,7 @@ export const clustersPage = {
 
     return cy.contains('table.resource-table th', 'Name', {timeout: 6000})
              .invoke('index')
-             .then((index) => cy.get('table.resource-table tbody tr').filter(':not(:contains("local-cluster"))').eq(0).get('td').eq(index).invoke('text'));
+             .then((index) => cy.get('table.resource-table tbody tr').filter(':not(:contains("local-cluster"))').filter(':not(:contains("console-ui-test-"))').eq(0).get('td').eq(index).invoke('text'));
   },
   shouldExist: () => {
     cy.get('.bx--detail-page-header-title').should('contain', 'Clusters')


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/7098

When running in the canaries, don't target any of the console-ui test clusters for this tests.

Testing with:
![image](https://user-images.githubusercontent.com/4671325/99309331-40260080-2827-11eb-8dd6-e7540514c5d3.png)
