### PR TITLE
Skip unresponsive test to stabilize canary

### DIFF
--- a/tests/cypress/tests/welcomePage.spec.js
+++ b/tests/cypress/tests/welcomePage.spec.js
@@ -38,14 +38,14 @@ describe('Welcome page', function () {
         leftNav.goToGRC()
     })
 
+    /* Skipping this test because it's intermittently becoming unresponsive and causing the canaries to fail.
     it('should be validated for the nav icons on the header', function () {
-        // Skipping this test because it's intermittently becoming unresponsive and causing the canaries to fail.
-        this.skip()
-        // userMenu.openApps()
-        // userMenu.openSearch()
-        // userMenu.openResources()
-        // userMenu.openTerminal()
-        // userMenu.openInfo()
-        // userMenu.openUser()
+        userMenu.openApps()
+        userMenu.openSearch()
+        userMenu.openResources()
+        userMenu.openTerminal()
+        userMenu.openInfo()
+        userMenu.openUser()
     })
+    */
 })


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/7424

Temporarily disabling unresponsive test to stabilize the canary.