### PR TITLE
Added condition to check if suggested filters are available for input.

### DIFF
--- a/tests/cypress/views/resource.js
+++ b/tests/cypress/views/resource.js
@@ -47,6 +47,7 @@ export const resourcePage = {
   },
   shouldCreateResource: () => {
     cy.get('.bx--btn--primary').click();
+    cy.get('.bx--inline-notification__subtitle').should('not.exist')
     cy.get('.bx--inline-notification', { timeout: 30000 }).should('not.exist');
     cy.get('.react-monaco-editor-container', { timeout: 30000 }).should('not.exist');
   }

--- a/tests/cypress/views/search.js
+++ b/tests/cypress/views/search.js
@@ -18,7 +18,10 @@ export const searchPage = {
   whenGoToSearchPage:() => cy.visit('/search'),
   
   whenExpandRelationshipTiles:() => {
-    cy.get('button.pf-c-button.pf-m-secondary', { timeout: 20000 }).focus().click()
+    cy.get('.pf-c-skeleton', {timeout: 2000}).should('not.exist')
+    cy.get('.pf-l-gallery', {timeout: 2000}).children().should('have.length.above', 1).then(() => {
+      cy.get('button.pf-c-button.pf-m-secondary', { timeout: 20000 }).focus().click()
+    })
   },
   whenGetResourceTableRow:(resource, name) => {
     return cy.get('tr').filter(`:contains("${name}")`)
@@ -101,14 +104,16 @@ export const searchBar = {
   whenClearFilters:() => {
     cy.get('#clear-all-search-tags-button').click()
   },
+  whenSuggestionsAreAvailable: () => {
+    cy.get('.react-tags__suggestions ul#ReactTags', {timeout: 20000}).children().should('have.length.above', 1)
+  },
   whenEnterTextInSearchBar:(property, value) => {
     cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').focus().click().type(property).wait(200)
     cy.get('.react-tags', {timeout: 20000}).should('exist')
-    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist')
-    cy.get('.react-tags__search-input', {timeout: 20000}).type(' ').wait(200)
+    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').type(' ').wait(200)
+    searchBar.whenSuggestionsAreAvailable()
     if (value && value !== null) {
-      cy.get('.react-tags__search-input', {timeout: 20000}).type(value)
-      cy.get('.react-tags__search-input', {timeout: 20000}).type(' ').wait(200)
+      cy.get('.react-tags__search-input', {timeout: 20000}).type(value).type(' ').wait(200)
     }
   },
   whenFilterByCluster:(cluster) => {


### PR DESCRIPTION
This should help the search input to remain in the correct format when being typed within the search bar during the tests. If we check to see if the react-tags are available and if some value is present, this should clear the disconnect of us continuously typing when the data is not present.

https://github.com/open-cluster-management/backlog/issues/9328