### PR TITLE
Increased logout timeout

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -132,7 +132,7 @@ Cypress.Commands.add('forEach', (selector, action, options) => {
 Cypress.Commands.add('logout', () => {
   cy.getCookie('acm-access-token-cookie').should('exist').then((token) => {
     oauthIssuer(token.value).then((issuer) => {
-      cy.get('#acm-user-dropdown').click().then(() => cy.get('#acm-logout').click().then(() => cy.url().should('include', issuer)))
+      cy.get('#acm-user-dropdown', {timeout: 20000}).click().then(() => cy.get('#acm-logout').click().then(() => cy.url().should('include', issuer)))
     })
   })
 })


### PR DESCRIPTION
Increasing the timeout out for getting the logout dropdown for the Search tests. This should help with the timeout issues, in the `after` phase of the test.

Issue: https://github.com/open-cluster-management/backlog/issues/9490