### PR TITLE
Added condition to filter the managed clusters for import-* cluster

### DIFF
--- a/tests/cypress/scripts/cliHelper.js
+++ b/tests/cypress/scripts/cliHelper.js
@@ -12,7 +12,7 @@ export const cliHelper = {
         if (process.env.NODE_ENV !== 'dev' || process.env.NODE_ENV !== 'debug') { // In the canary tests, we only need to focus on the import-xxxx managed cluster.
           targetCluster = managedClusters.find((c) => c.startsWith('import-'))
         } else { // We need to access a managed cluster locally.
-          targetCluster = managedClusters.find((c) => !c.includes('local-cluster')
+          targetCluster = managedClusters.find((c) => !c.includes('local-cluster'))
         }
 
         return cy.wrap(targetCluster)


### PR DESCRIPTION
This will fix the issue that is occurring within our tests that will select the wrong managed cluster. In our canary test, we should be focusing on the `import-*` cluster; however, when multiple clusters are available, we tend to select the wrong one. This will add a condition to only find the cluster that starts with `import-`.

https://github.com/open-cluster-management/backlog/issues/9789