### PR TITLE
[release-2.2] Added timeout to prevent tests from hanging

### DIFF
--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -22,6 +22,7 @@ import './commands'
 require('cypress-terminal-report/src/installLogsCollector')()
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED='0'
+var timeoutID
 
 before(() => {
   cy.clearCookies()
@@ -29,7 +30,11 @@ before(() => {
 
 beforeEach(() => {
   Cypress.Cookies.preserveOnce('acm-access-token-cookie', '_oauth_proxy', 'XSRF-TOKEN', '_csrf')
+  timeoutID = setTimeout(() => {
+    throw Error('Test taking too long! It has been running for 5 minutes.')
+  }, 60000 * 5)
 })
 
-after(()=> {
+afterEach(()=> {
+  clearTimeout(timeoutID)
 })

--- a/tests/cypress/tests/linkPage.spec.js
+++ b/tests/cypress/tests/linkPage.spec.js
@@ -18,11 +18,11 @@ describe('Search: Linked page', function () {
         cy.logout()
     })
 
-    it(`[${squad}] overview page should has link to search page`, function () {
+    it(`[P2][Sev2][${squad}] overview page should has link to search page`, function () {
         overviewPage.shouldHaveLinkToSearchPage()
     })
 
-    it(`[${squad}] clusters page should has link to search page`, function () {
+    it(`[P2][Sev2][${squad}] clusters page should has link to search page`, function () {
         clustersPage.shouldHaveLinkToSearchPage()
     })
 })


### PR DESCRIPTION
Adding a timeout to prevent tests from hanging within the canary builds.