### PR TITLE
Removed related element search for suggested searches

### DIFF
--- a/tests/cypress/tests/suggestedSearches.spec.js
+++ b/tests/cypress/tests/suggestedSearches.spec.js
@@ -25,19 +25,16 @@ describe('Search: Verify the suggested search templates', function() {
   it(`[P3][Sev3][${squad}] should see the workloads template & search tag in search items`, function() {
     savedSearches.whenSelectCardWithTitle('Workloads')
     searchBar.shouldContainTag('kind:daemonset,deployment,job,statefulset,replicaset')
-    savedSearches.whenRelatedItemsExist()
   });
 
   it(`[P3][Sev3][${squad}] should see the unhealthy pods template & search tag in search items`, function() {
     savedSearches.whenSelectCardWithTitle('Unhealthy pods')
     searchBar.shouldContainTag('kind:pod')
     searchBar.shouldContainTag('status:Pending,Error,Failed,Terminating,ImagePullBackOff,CrashLoopBackOff,RunContainerError,ContainerCreating')
-    savedSearches.whenRelatedItemsExist()
   });
 
   it(`[P3][Sev3][${squad}] should see the created last hour template & search tag in search items`, function() {
     savedSearches.whenSelectCardWithTitle('Created last hour')
     searchBar.shouldContainTag('created:hour')
-    savedSearches.whenRelatedItemsExist()
   });
 })


### PR DESCRIPTION
Within the cluster, it's possible for the resources not to be available when searching for the suggested searches. To stabilize the canary builds, it would be best to keep them removed.