### PR TITLE
Added fix to select imported cluster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3455,6 +3455,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "test": "npm run test:clean-reports && npm run test:headless && npm run test:merge-reports",
     "test:api": "jest --colors",
     "test:clean-reports": "rm -rf ./results",
+    "test:debug": "cross-env NODE_ENV=debug ./start-tests.sh",
     "test:headed": "export LIVE_MODE=true && export BROWSER=chrome && ./start-tests.sh",
-    "test:headless": "set -e NODE_ENV=dev && ./start-tests.sh",
+    "test:headless": "cross-env NODE_ENV=development ./start-tests.sh",
     "test:merge-json": "npx mochawesome-merge results/json/*.json -o results/json/mochawesome-merge-results.json",
     "test:merge-reports": "npm run test:merge-xml && npm run test:merge-json",
-    "test:merge-xml": "npx junit-merge --dir=results -o results/merge-test-results.xml"
+    "test:merge-xml": "npx junit-merge --dir=results -o results/merge-test-results.xml",
+    "test:production": "cross-env NODE_ENV=production ./start-tests.sh"
   },
   "repository": {
     "type": "git",
@@ -36,6 +38,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^3.8.1",
     "chromedriver": "^87.0.5",
+    "cross-env": "^7.0.3",
     "cypress": "^5.3.0",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-terminal-report": "^2.0.0",

--- a/start-tests.sh
+++ b/start-tests.sh
@@ -55,17 +55,22 @@ if [[ "$LIVE_MODE" == true ]]; then
   HEADLESS=""
 fi
 
+if [ -z "$NODE_ENV" ]; then
+  export NODE_ENV="production" || set NODE_ENV="production"
+fi
+
+echo -e "Setting env to run in: $NODE_ENV"
+
 section_title "Running Search API tests."
 npm run test:api
 
-
 section_title "Running Search UI tests."
-if [ "$NODE_ENV" == "dev" ]; then
-  npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters  
+if [ "$NODE_ENV" == "development" ]; then
+  npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters --env NODE_ENV=$NODE_ENV
 elif [ "$NODE_ENV" == "debug" ]; then
-  npx cypress open --browser $BROWSER --config numTestsKeptInMemory=0
+  npx cypress open --browser $BROWSER --config numTestsKeptInMemory=0 --env NODE_ENV=$NODE_ENV
 else 
-  cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters
+  cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters --env NODE_ENV=$NODE_ENV
 fi
 
 testCode=$?

--- a/tests/cypress/scripts/cliHelper.js
+++ b/tests/cypress/scripts/cliHelper.js
@@ -4,11 +4,23 @@
  ****************************************************************************** */
 
 export const cliHelper = {
-    getTargetManagedCluster: () => {
-      return cy.exec('oc get managedclusters -o custom-columns=NAME:.metadata.name').then(result => {
-        const managedClusters = result.stdout.split('\n').slice(1)
-        const targetCluster = managedClusters.find(c => !c.includes('local-cluster') && !c.includes('console-ui-test-'))
-        return cy.wrap(targetCluster)
-      })
-    }
+  getTargetManagedCluster: () => {
+    return cy.exec('oc get managedclusters -o custom-columns=NAME:.metadata.name').then(result => {
+      const managedClusters = result.stdout.split('\n').slice(1)
+      let targetCluster
+
+      // In the canary tests, we only need to focus on the import-xxxx managed cluster.
+      if (Cypress.env('NODE_ENV') !== 'development' && Cypress.env('NODE_ENV') !== 'debug') {
+        targetCluster = managedClusters.find((c) => c.startsWith('import-'))
+      }
+      
+      // When running locally or if the cluster is not available, try testing on an available managed cluster.
+      if (targetCluster === undefined) {
+        targetCluster = managedClusters.find((c) => !c.includes('local-cluster'))
+      }
+
+      cy.log(`Testing with Managed Cluster: ${targetCluster}`)
+      return cy.wrap(targetCluster)
+    })
   }
+}


### PR DESCRIPTION
In the canaries, we need to select the managed cluster: `import-*`. This is fixed in 2.3, but not in 2.2.