### PR TITLE
removed redundant assertions and timeout overrides

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -46,10 +46,10 @@ Cypress.Commands.add('login', (OPTIONS_HUB_USER, OPTIONS_HUB_PASSWORD, OC_IDP) =
       // Check if identity providers are configured
       if (body.find('form').length === 0)
         cy.contains(idp).click()
-      cy.get('#inputUsername', { timeout: 20000 }).click().focused().type(user)
-      cy.get('#inputPassword', { timeout: 20000 }).click().focused().type(password)
-      cy.get('button[type="submit"]', { timeout: 20000 }).click()
-      cy.get('.app-header', { timeout: 30000 }).should('exist')
+      cy.get('#inputUsername').click().focused().type(user)
+      cy.get('#inputPassword').click().focused().type(password)
+      cy.get('button[type="submit"]').click()
+      cy.get('.app-header', { timeout: 30000 })
     }
   })
 })
@@ -131,7 +131,7 @@ Cypress.Commands.add('forEach', (selector, action, options) => {
 Cypress.Commands.add('logout', () => {
   cy.getCookie('acm-access-token-cookie').should('exist').then((token) => {
     oauthIssuer(token.value).then((issuer) => {
-      cy.get('#acm-user-dropdown', {timeout: 20000}).click().then(() => cy.get('#acm-logout').click().then(() => cy.url().should('include', issuer)))
+      cy.get('#acm-user-dropdown').click().then(() => cy.get('#acm-logout').click().then(() => cy.url().should('include', issuer)))
     })
     // Clearing cookies for rbac users
     cy.location('pathname').should('match', new RegExp('/oauth/authorize(\\?.*)?$'))

--- a/tests/cypress/views/deploymentDetailPage.js
+++ b/tests/cypress/views/deploymentDetailPage.js
@@ -10,7 +10,7 @@
 export const deploymentDetailPage = {
   whenScaleReplicasTo:(replicas) => {
     cy.wait(2000) // DOM element tends to detach within cypress at this point. Adding a slight delay to avoid that scenario.
-    cy.get('button.pf-m-primary').click({ timeout: 20000, force: true }).wait(1000)
+    cy.get('button.pf-m-primary').click({ force: true }).wait(1000)
     cy.get('.react-monaco-editor-container').click().type(Cypress.platform !== 'darwin' ? '{ctrl}f' : '{meta}f')
       .get('.find-widget .monaco-inputbox textarea:first').focus().click().type('replicas: 1')
     cy.get('.react-monaco-editor-container .view-line > span')

--- a/tests/cypress/views/popup.js
+++ b/tests/cypress/views/popup.js
@@ -13,5 +13,5 @@ export const popupModal = {
     popupModal.shouldNotExist()
   },
   shouldNotExist:() => cy.get('button.pf-m-danger', { timeout: 30000 }).should('not.exist'),
-  shouldExist:() => cy.get('button.pf-m-danger', { timeout: 30000 }).should('exist')
+  shouldExist:() => cy.get('button.pf-m-danger', { timeout: 30000 })
 }

--- a/tests/cypress/views/resource.js
+++ b/tests/cypress/views/resource.js
@@ -9,9 +9,9 @@ import { searchBar } from "./search";
 const typeDelay = 1
 
 export const resourcePage = {
-  whenGoToResourcePage: () => cy.get('#acm-create-resource', { timeout: 20000 }).click(),
+  whenGoToResourcePage: () => cy.get('#acm-create-resource').click(),
   whenSelectTargetCluster: (clusterName) => {
-    cy.get('#create-resource-select', { timeout: 20000 }).click()
+    cy.get('#create-resource-select').click()
     cy.get('.bx--checkbox-wrapper input[name="' + clusterName + '"]').parent().click()
   },
   whenCreateNamespace: (namespace, previouslyCreated=false) => {
@@ -50,7 +50,7 @@ export const resourcePage = {
     cy.get('.bx--btn--primary', {timeout: 30000}).click();
 
     if (previouslyCreated) { // Test both scenarios if resource already exist or not.
-      cy.get('.bx--inline-notification__subtitle').should('exist').contains('already exist')
+      cy.get('.bx--inline-notification__subtitle').contains('already exist')
     } else {
       cy.get('.bx--inline-notification__subtitle').should('not.exist')
       cy.get('.bx--inline-notification', { timeout: 30000 }).should('not.exist');

--- a/tests/cypress/views/savedSearches.js
+++ b/tests/cypress/views/savedSearches.js
@@ -42,26 +42,26 @@ export const savedSearches = {
     for (var key in filterOptions){
       searchBar.whenEnterTextInSearchBar(key, filterOptions[key])
     }
-    cy.get('.pf-c-button.pf-m-primary',{timeout: 20000}).contains('Save search').should('exist').focus().click()
-    cy.get('#add-query-name', {timeout: 20000}).type(queryName)
-    cy.get('#add-query-desc', {timeout: 20000}).type(queryDesc)
-    cy.get('.pf-c-modal-box__footer', {timeout: 20000}).contains('Save').should('exist').focus().click()
+    cy.get('.pf-c-button.pf-m-primary').contains('Save search').focus().click()
+    cy.get('#add-query-name').type(queryName)
+    cy.get('#add-query-desc').type(queryDesc)
+    cy.get('.pf-c-modal-box__footer').contains('Save').focus().click()
   },
 
   editSavedSearch: (queryName, editedName, editedDesc) => {
     searchPage.whenGoToSearchPage()
-    cy.get('.pf-c-title.pf-m-md').contains('Saved searches').should('exist')
-    cy.get('.pf-c-card__header').contains(queryName).should('exist').parent().siblings().find('button').click()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches')
+    cy.get('.pf-c-card__header').contains(queryName).parent().siblings().find('button').click()
     cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Edit').click()
     cy.get('#add-query-name').clear().type(editedName)
     cy.get('#add-query-desc').clear().type(editedDesc)
-    cy.get('.pf-c-modal-box__footer').contains('Save').should('exist').focus().click()
+    cy.get('.pf-c-modal-box__footer').contains('Save').focus().click()
   },
 
   shareSavedSearch: (queryName) => {
     searchPage.whenGoToSearchPage()
-    cy.get('.pf-c-title.pf-m-md').contains('Saved searches').should('exist')
-    cy.get('.pf-c-card__header').contains(queryName).should('exist').parent().siblings().find('button').click()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches')
+    cy.get('.pf-c-card__header').contains(queryName).parent().siblings().find('button').click()
     cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Share').click()
     cy.get(".pf-c-code-editor__code").find('pre').invoke('text').then((urlText) => {
       cy.visit(urlText.toString());
@@ -70,15 +70,15 @@ export const savedSearches = {
 
   getSavedSearch: (queryName) => {
     searchPage.whenGoToSearchPage()
-    cy.get('.pf-c-title.pf-m-md', {timeout: 20000}).contains('Saved searches').should('exist')
-    cy.get('button.pf-c-dropdown__toggle', {timeout: 20000}).contains('Saved searches').should('exist').click({force: true})
-    cy.get('ul.pf-c-dropdown__menu.pf-m-align-right', {timeout: 20000}).contains(queryName).click()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches')
+    cy.get('button.pf-c-dropdown__toggle').contains('Saved searches').click({force: true})
+    cy.get('ul.pf-c-dropdown__menu.pf-m-align-right').contains(queryName).click()
   },
 
   whenDeleteSavedSearch: (queryName) => {
     searchPage.whenGoToSearchPage()
-    cy.get('.pf-c-title.pf-m-md', {timeout: 20000}).contains('Saved searches').should('exist')
-    cy.get('.pf-c-card__header', {timeout: 20000}).contains(queryName).should('exist').parent().siblings().find('button').click()
+    cy.get('.pf-c-title.pf-m-md').contains('Saved searches')
+    cy.get('.pf-c-card__header').contains(queryName).parent().siblings().find('button').click()
     cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Delete').click()
     cy.get('.pf-c-button.pf-m-danger').contains('Delete').click().reload()
     cy.get('.pf-c-card__title').contains(queryName).should('not.exist')

--- a/tests/cypress/views/search.js
+++ b/tests/cypress/views/search.js
@@ -19,7 +19,7 @@ export const searchPage = {
   whenExpandRelationshipTiles:() => {
     cy.get('.pf-c-skeleton', {timeout: 2000}).should('not.exist')
     cy.get('.pf-l-gallery', {timeout: 2000}).children().should('have.length.above', 1).then(() => {
-      cy.get('button.pf-c-button.pf-m-secondary', { timeout: 20000 }).focus().click()
+      cy.get('button.pf-c-button.pf-m-secondary').focus().click()
     })
   },
   whenGetResourceTableRow:(resource, name) => {
@@ -52,15 +52,15 @@ export const searchPage = {
 
   whenReloadUntilFindResults: (options) => {
     cy.reloadUntil(async() => {
-      cy.get('.pf-c-table', { timeout: 30000 }).should('exist')
+      cy.get('.pf-c-table', { timeout: 30000 })
     }, options)
   },
  
   shouldLoadResults:() => cy.get('.pf-c-spinner', { timeout: 30000 }).should('not.exist'),
 
   shouldLoad:() => {
-    cy.get('.react-tags', {timeout: 20000}).should('exist')
-    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist')
+    cy.get('.react-tags')
+    cy.get('.react-tags__search-input')
   },
 
   shouldFindNoResults: () => {
@@ -80,10 +80,10 @@ export const searchPage = {
     cy.contains('.search--resource-table-header-button', resource, {timeout: 6000})
   },
   shouldFindAnyResourceDetail: () => {
-    cy.get('.search--resource-table-header-button', {timeout: 6000 }).should('exist')
+    cy.get('.search--resource-table-header-button', {timeout: 6000 })
   },
   shouldFindResourceDetailItem: (resource, name) => {
-    searchPage.whenGetResourceTableRow(resource, name).should('exist')
+    searchPage.whenGetResourceTableRow(resource, name)
   },
   shouldBeResourceDetailItemCreatedFewSecondsAgo: (resource, name) => {
     cy.reloadUntil(() => {
@@ -116,27 +116,27 @@ export const searchPage = {
 
 export const searchBar = {
   whenFocusSearchBar:() => {
-    cy.get('.react-tags', {timeout: 20000}).click()
+    cy.get('.react-tags').click()
   },
   whenClearFilters:() => {
-    cy.get('#clear-all-search-tags-button', {timeout: 20000}).should('exist').click({force: true})
+    cy.get('#clear-all-search-tags-button').click({force: true})
   },
   whenSuggestionsAreAvailable: (value, ignoreIfDoesNotExist=false) => {
     if(!ignoreIfDoesNotExist) {
-      cy.get('.react-tags__suggestions ul#ReactTags', {timeout: 20000}).children().should('have.length.above', 1)
+      cy.get('.react-tags__suggestions ul#ReactTags').children().should('have.length.above', 1)
     }
-    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').click().type(value)
+    cy.get('.react-tags__search-input').click().type(value)
   },
   whenEnterTextInSearchBar:(property, value, ignoreIfDoesNotExist=false) => {
-    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').click()
+    cy.get('.react-tags__search-input').click()
     searchBar.whenSuggestionsAreAvailable(property, ignoreIfDoesNotExist)
 
-    cy.get('.react-tags', {timeout: 20000}).should('exist')
-    cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').type(' ').wait(100)
+    cy.get('.react-tags')
+    cy.get('.react-tags__search-input').type(' ').wait(100)
 
     if (value && value !== null) {
       searchBar.whenSuggestionsAreAvailable(value, ignoreIfDoesNotExist)
-      cy.get('.react-tags__search-input', {timeout: 20000}).should('exist').type(' ').wait(100)
+      cy.get('.react-tags__search-input').type(' ').wait(100)
     }
   },
   whenFilterByCluster:(cluster) => {

--- a/tests/cypress/views/suggestedSearches.js
+++ b/tests/cypress/views/suggestedSearches.js
@@ -16,12 +16,12 @@ export const savedSearches = {
     cy.get('.pf-c-card__title').contains(title).click()
   },
   whenRelatedItemsExist:()  => {
-    cy.get('.pf-l-gallery', {timeout: 20000}).get('.pf-c-skeleton', {timeout: 20000}).should('not.exist')
-    cy.get('.pf-l-gallery', {timeout: 20000}).children().should('exist').and('have.length.above', 1)
+    cy.get('.pf-l-gallery').get('.pf-c-skeleton').should('not.exist')
+    cy.get('.pf-l-gallery').children().and('have.length.above', 1)
   },
   whenGetRelatedItemDetails:(resource) => {
-    return cy.contains('.search--resource-table', resource, {timeout: 20000})
-      .find('table.bx--data-table-v2 tbody tr', {timeout: 20000})
+    return cy.contains('.search--resource-table', resource)
+      .find('table.bx--data-table-v2 tbody tr')
       .parent();
   },
   whenVerifyRelatedItemsDetails:() => {
@@ -32,7 +32,7 @@ export const savedSearches = {
         cy.get('.bx--tile-content > :nth-child(1) > .content > .text').each(($el) => {
           const itemName = $el.text()
           cy.wrap($el).click()
-        suggestedTemplate.whenGetRelatedItemDetails(itemName).should('exist', {timeout: 20000} )
+        suggestedTemplate.whenGetRelatedItemDetails(itemName).should('exist')
         cy.wrap($el).click()
         })
       }

--- a/tests/cypress/views/welcome.js
+++ b/tests/cypress/views/welcome.js
@@ -175,9 +175,9 @@ export const leftNav = {
 
 export const userMenu = {
     openApps: () => {
-        cy.get('.navigation-container #acm-apps-dropdown', {timeout: 20000}).click()
-        cy.get('.dropdown-content-header', {timeout: 20000})
-        cy.get('#applications a.dropwdown-content-items', {timeout: 20000}).should('have.attr', 'href').and('contain', 'console-openshift-console')
+        cy.get('.navigation-container #acm-apps-dropdown').click()
+        cy.get('.dropdown-content-header')
+        cy.get('#applications a.dropwdown-content-items').should('have.attr', 'href').and('contain', 'console-openshift-console')
     },
     openSearch: () => {
         cy.get('.navigation-container #acm-search').click()
@@ -203,8 +203,8 @@ export const userMenu = {
         cy.get('#acm-doc a').should('have.attr', 'href').and('contain', 'https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/')
         cy.getCookie('acm-access-token-cookie').should('exist').then((token, c) => {
             acmVersion(token.value).then((version) => {
-                cy.get('#acm-about').click().get('.bx--loading', {timeout: 20000}).should('not.exist')
-                cy.get('.version-details').should('exist').get('.version-details__no').should('contain', version)
+                cy.get('#acm-about').click().get('.bx--loading').should('not.exist')
+                cy.get('.version-details').get('.version-details__no').should('contain', version)
                 cy.get('.bx--modal-close').click()
             })
         })


### PR DESCRIPTION
This PR will focus on removing:
- `20000ms` timeout (by default it is `15000ms` , so that should be long enough)
-  `.should('exist')` from `cy.get(...)` functions (by default, `cy.get` is already checking to see if the element exist)