### PR TITLE
Fixed conditional statement for redisgraph check

### DIFF
--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -29,14 +29,14 @@ const err = 'Test taking too long! It has been running for 5 minutes.'
 before(() => {
   // This is needed for search to deploy RedisGraph upstream. Without this search won't be operational.
   cy.exec('oc get srcho searchoperator -o jsonpath="{.status.deployredisgraph}" -n open-cluster-management', {failOnNonZeroExit: false}).then(result => {
-        if (result.code == "true"){
-          cy.task('log', 'Redisgraph deployment is enabled.')
-        } else {
-          cy.task('log', 'Redisgraph deployment disabled, enabling and waiting 10 seconds for the search-redisgraph-0 pod.')
-          cy.exec('oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n open-cluster-management')
-          return cy.wait(10*1000)
-      }
-    })
+    if (result.stdout == "true"){
+      cy.task('log', 'Redisgraph deployment is enabled.')
+    } else {
+      cy.task('log', 'Redisgraph deployment disabled, enabling and waiting 10 seconds for the search-redisgraph-0 pod.')
+      cy.exec('oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n open-cluster-management')
+      return cy.wait(10*1000)
+    }
+  })
   cy.clearCookies()
 })
 


### PR DESCRIPTION
Updated conditional statement in `support/index.js` file. The statement was checking to see if the `res.code` was equal to `"true"`. This would fail since it was always set to 0; therefore, we needed to change it to `res.stdout` instead.