### PR TITLE
Updated links page test to reflect cluster page changes.

### DIFF
--- a/tests/cypress/views/clusters.js
+++ b/tests/cypress/views/clusters.js
@@ -7,7 +7,7 @@
 
 export const clustersPage = {
   shouldExist: () => {
-    cy.get('.pf-c-title').should('contain', 'Cluster management')
+    cy.get('.pf-c-title').should('contain', 'Cluster')
   },
   shouldHaveLinkToSearchPage: () => {
     cy.visit('/multicloud/clusters')


### PR DESCRIPTION
This PR will just update the test to work with the latest cluster page changes. The changes were causing our test to fail in the canaries.

https://github.com/open-cluster-management/backlog/issues/12481