### PR TITLE
removed saved searches deletion from after hook

### DIFF
--- a/tests/cypress/tests/08-saved/01-saved-searches.spec.js
+++ b/tests/cypress/tests/08-saved/01-saved-searches.spec.js
@@ -21,11 +21,6 @@ describe('RHACM4K-412 - Search: Saved searches', function() {
     cy.login()
   })
 
-  after(function() {
-    savedSearches.whenDeleteSavedSearch(queryDefaultNamespaceName)
-    savedSearches.whenDeleteSavedSearch(queryOcmaNamespaceName)
-  })
-
   it(`[P2][Sev2][${squad}] should find each managed cluster has default namespace`, function() {
     savedSearches.validateClusterNamespace({'namespace': 'default'}, '')
   })
@@ -59,5 +54,13 @@ describe('RHACM4K-412 - Search: Saved searches', function() {
 
   it(`[P2][Sev2][${squad}] should be able to share the saved searches`, function() {
     savedSearches.shareSavedSearch(queryDefaultNamespaceName)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to delete the saved searches ${queryDefaultNamespaceName}`, function() {
+    savedSearches.whenDeleteSavedSearch(queryDefaultNamespaceName)
+  })
+
+  it(`[P2][Sev2][${squad}] should be able to delete the saved search ${queryOcmaNamespaceName}`, function() {
+    savedSearches.whenDeleteSavedSearch(queryOcmaNamespaceName)
   })
 })


### PR DESCRIPTION
This PR will add remove the saved searches deletion and add them within their own individual tests. If the deletion fails in the `after` hook, the test will not retry, which will result in the resources never being deleted.

Canary issues: https://github.com/open-cluster-management/backlog/issues/14283 & https://github.com/open-cluster-management/backlog/issues/14258

![RHACM4K-412 - Search Saved searches --  P2 Sev2 observability-usa  should be able to share the saved searches -- after all hook (failed)](https://user-images.githubusercontent.com/28898909/125674783-591ab57e-ba32-499c-a1f5-5c087a102336.png)
