### PR TITLE
[2.5] Updated search metadata to Observability

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -30,7 +30,7 @@ nconf
     CLUSTER_VIEWER_USR: 'user-viewer',
     CLUSTER_VIEWER_PWD: 'pass-viewer',
     contextPath: '/multicloud',
-    squadName: 'observability-usa',
+    squadName: 'observability',
   })
 
 // Hack to deal with camelCase when using env OPTIONS_HUB_BASEDOMAIN OPTIONS_HUB_USER OPTIONS_HUB_PASSWORD

--- a/tests/cypress/config/index.js
+++ b/tests/cypress/config/index.js
@@ -6,7 +6,7 @@
 /**
  * Squad label displayed within the test metadata (Required by CICD).
  */
-export const squad = 'observability-usa'
+export const squad = 'observability'
 
 /**
  * Tags to determine the test environment.


### PR DESCRIPTION
Updating the search-e2e metadata to observability. (squad:observability-usa is deprecated)
Signed-off-by: dislbenn <lavontae.bennett@gmail.com>