### PR TITLE
Remove use of deprecated API for SA token

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -6,7 +6,7 @@ mkdir clis-unpacked
 
 # Install OpenShift and Kubectl CLI.
 echo 'Installing oc and kubectl clis...'
-curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.11.2/openshift-client-linux-4.11.2.tar.gz
+curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.11.3/openshift-client-linux-4.11.3.tar.gz
 tar -xzf oc.tar.gz -C clis-unpacked
 chmod 755 ./clis-unpacked/oc
 chmod 755 ./clis-unpacked/kubectl

--- a/tests/api/common.test.js
+++ b/tests/api/common.test.js
@@ -8,7 +8,7 @@ const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient'
 
 const _ = require('lodash')
 
-describe('RHACM4K-1696: Search API - Verify search result with common filter and conditions', () => {
+describe.skip('RHACM4K-1696: Search API - Verify search result with common filter and conditions', () => {
   beforeAll(async () => {
     // Log in and get access token
     token = getKubeadminToken()

--- a/tests/api/common.test.js
+++ b/tests/api/common.test.js
@@ -8,7 +8,7 @@ const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient'
 
 const _ = require('lodash')
 
-describe.skip('RHACM4K-1696: Search API - Verify search result with common filter and conditions', () => {
+describe('RHACM4K-1696: Search API - Verify search result with common filter and conditions', () => {
   beforeAll(async () => {
     // Log in and get access token
     token = getKubeadminToken()

--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -46,7 +46,7 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     searchApiRoute = route
 
     await sleep(20000) // Wait for the service account and search index to get updated.
-    user = await getUserContext({ usr, ns, retryWait: 5000 })
+    user = await getUserContext({ usr, ns })
   }, 60000)
 
   afterAll(async () => {

--- a/tests/api/rbac.test.js
+++ b/tests/api/rbac.test.js
@@ -62,7 +62,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
 
   describe(`with user ${usr0} (not authorized to list any resources)`, () => {
     beforeAll(async () => {
-      user = await getUserContext({ usr: usr0, ns, retryWait: 4000 })
+      user = await getUserContext({ usr: usr0, ns })
     })
 
     test('should validate RBAC configuration for user', () => {
@@ -88,7 +88,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
 
   describe(`with user ${usr1} (configmap in namespace ${ns} only)`, () => {
     beforeAll(async () => {
-      user = await getUserContext({ usr: usr1, ns, retryWait: 4000 })
+      user = await getUserContext({ usr: usr1, ns })
     })
 
     test('should validate RBAC configuration for user', () => {
@@ -114,7 +114,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
 
   describe(`with user ${usr2} (nodes and configmap in all namespaces.)`, () => {
     beforeAll(async () => {
-      user = await getUserContext({ usr: usr2, ns, retryWait: 4000 })
+      user = await getUserContext({ usr: usr2, ns })
     })
 
     test('should validate RBAC configuration for user', () => {
@@ -131,7 +131,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
 
   describe(`with user ${usr3} (admin for namespace ${ns})`, () => {
     beforeAll(async () => {
-      user = await getUserContext({ usr: usr3, ns, retryWait: 4000 })
+      user = await getUserContext({ usr: usr3, ns })
     })
 
     test('should validate RBAC configuration for user', () => {
@@ -160,7 +160,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
 
   describe(`with user ${usr4} (access to deployment but not pod)`, () => {
     beforeAll(async () => {
-      user = await getUserContext({ usr: usr4, ns, retryWait: 4000 })
+      user = await getUserContext({ usr: usr4, ns })
     })
 
     test('should validate RBAC configuration.', () => {


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/25507
Issue: https://github.com/stolostron/backlog/issues/25200

### Changes
-Changes `oc serviceaccounts get-token ...` to `oc create token ...`