### PR TITLE
Remove search result validation from suggested search tests

### DIFF
--- a/tests/cypress/tests/suggested-searches.spec.js
+++ b/tests/cypress/tests/suggested-searches.spec.js
@@ -19,7 +19,6 @@ describe('RHACM4K-411: Search: Verify the suggested search templates', { tags: t
     it(`[P3][Sev3][${squad}] should see the workloads template & search tag in search items`, function () {
       suggestedSearches.whenSelectCardWithTitle('Workloads')
       searchBar.shouldContainTag('kind:daemonset,deployment,job,statefulset,replicaset')
-      suggestedSearches.whenVerifyRelatedItemsDetails()
     })
 
     it(`[P3][Sev3][${squad}] should see the unhealthy pods template & search tag in search items`, function () {
@@ -28,13 +27,11 @@ describe('RHACM4K-411: Search: Verify the suggested search templates', { tags: t
       searchBar.shouldContainTag(
         'status:Pending,Error,Failed,Terminating,ImagePullBackOff,CrashLoopBackOff,RunContainerError,ContainerCreating'
       )
-      suggestedSearches.whenVerifyRelatedItemsDetails()
     })
 
     it(`[P3][Sev3][${squad}] should see the created last hour template & search tag in search items`, function () {
       suggestedSearches.whenSelectCardWithTitle('Created last hour')
       searchBar.shouldContainTag('created:hour')
-      suggestedSearches.whenVerifyRelatedItemsDetails()
     })
   })
 })

--- a/tests/cypress/views/suggestedSearches.js
+++ b/tests/cypress/views/suggestedSearches.js
@@ -5,8 +5,6 @@
 
 /// <reference types="cypress" />
 
-import { searchPage } from './search'
-
 /**
  * Suggested searches object for the Search page within the ACM console.
  */
@@ -17,32 +15,5 @@ export const suggestedSearches = {
    */
   whenSelectCardWithTitle: (title) => {
     cy.get('.pf-c-card__title').filter(`:contains(${title})`).should('exist').and('be.visible').click()
-  },
-  /**
-   * Verify the related resource item details within the Search page.
-   */
-  whenVerifyRelatedItemsDetails: () => {
-    searchPage.shouldLoad()
-
-    cy.get('body').then((body) => {
-      if (body.find('.pf-c-expandable-section__toggle').length === 0) {
-        cy.get('.pf-c-alert.pf-m-inline.pf-m-info').should('exist').and('be.visible')
-      } else {
-        cy.get('.pf-c-expandable-section__toggle').filter(':contains(Show related resources)').should('exist').click()
-
-        cy.get('.pf-l-grid.pf-m-gutter')
-          .should('exist')
-          .then(($related) => {
-            if ($related.children().length > 0) {
-              cy.get('.pf-c-tile__body .pf-c-skeleton')
-                .should('not.exist')
-                .then(() => {
-                  cy.get('.pf-c-tile__body').first().click()
-                  cy.get('.pf-c-expandable-section__toggle-text').should('exist').and('contain', 'Related')
-                })
-            }
-          })
-      }
-    })
   },
 }


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issues: 
- https://github.com/stolostron/backlog/issues/25680
- https://github.com/stolostron/backlog/issues/25681


The validation for suggested search results can error intermittently due to some suggested searches having 0 results. I am removing the search result validation as this is already done in the search tests.