### PR TITLE
Remove tests dependency on kube creating pods

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -169,17 +169,7 @@ echo -e "Logged in as user: $(oc whoami)\n"
 export CYPRESS_ACM_VERSION=`oc get subscriptions.operators.coreos.com -A -o yaml | grep currentCSV:\ advanced-cluster-management | awk '{$1=$1};1' | sed "s/currentCSV:\ advanced-cluster-management.v//"`
 log_color "green" "Testing with ACM Version": "$CYPRESS_ACM_VERSION\n"
 
-log_color "cyan" "Checking RedisGraph deployment."
 installNamespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
-rgstatus=`oc get srcho searchoperator -o jsonpath="{.status.deployredisgraph}" -n $installNamespace`
-
-if [[ "$rgstatus" == "true" ]]; then
-  echo -e "RedisGraph deployment is enabled.\n"
-else
-  echo -e "RedisGraph deployment disabled, enabling and waiting 60 seconds for the search-redisgraph-0 pod.\n"
-  oc set env deploy search-operator DEPLOY_REDISGRAPH="true" -n $installNamespace
-  sleep 60
-fi
 
 # Search for managed clusters.
 MANAGED_CLUSTERS=($(oc get managedclusters -o custom-columns='name:.metadata.name' --no-headers))

--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -73,15 +73,11 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
       expect(items[0]).toHaveProperty('name', 'cm2-apple')
     })
 
-    if (SEARCH_API_V1) {
-      test('should be case insensitive.', async () => {
-        const items = await resolveSearchItems(user.token, { keywords: ['ApPLe'] })
-        expect(items).toHaveLength(1)
-        expect(items[0]).toHaveProperty('name', 'cm2-apple')
-      })
-    } else {
-      test.skip('(SKIPPED V2) should be case insensitive', () => {})
-    }
+    test('should be case insensitive.', async () => {
+      const items = await resolveSearchItems(user.token, { keywords: ['ApPLe'] })
+      expect(items).toHaveLength(1)
+      expect(items[0]).toHaveProperty('name', 'cm2-apple')
+    })
 
     test(`should match resources where label text contains 'vegetable'`, async () => {
       const items = await resolveSearchItems(user.token, { keywords: ['vegetable'] })

--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -17,7 +17,7 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     let setupCommands = `# export ns=search-query; export usr=search-query-user
     oc create namespace ${ns}
     oc create serviceaccount ${usr} -n ${ns}
-    oc create role ${usr} --verb=get,list --resource=configmaps,deployments,replicasets,pods -n ${ns}
+    oc create role ${usr} --verb=get,list --resource=configmaps,deployments,replicasets -n ${ns}
     oc create rolebinding ${usr} --role=${usr} --serviceaccount=${ns}:${usr} -n ${ns}
 
     oc create configmap cm0 -n ${ns} --from-literal=key=cm0
@@ -29,9 +29,7 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     oc create configmap cm4-broccoli -n ${ns} --from-literal=key=cm4
     oc label configmap cm4-broccoli -n ${ns} type=vegetable
 
-    oc create deployment ${usr} -n ${ns} --image=busybox --replicas=1 -- 'date; sleep 1; date; sleep 5;'
-    oc patch deployment ${usr} -n ${ns} -p '{"spec":{"template":{"spec":{"containers":[{"name":"busybox","imagePullPolicy":"IfNotPresent"}]}}}}'
-    oc scale deployment ${usr} -n ${ns} --replicas=5
+    oc create deployment ${usr} -n ${ns} --image=busybox --replicas=0 -- 'date; sleep 60;'
     `
 
     // The V1 logic requires that user has access to list namespaces.
@@ -137,16 +135,18 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
           { property: 'created', values: ['hour'] },
         ],
       })
-      expect(items).toHaveLength(10)
+      expect(items).toHaveLength(9)
     })
 
-    test('should match resources where desired = 5', async () => {
-      const items = await resolveSearchItems(user.token, { filters: [{ property: 'desired', values: ['=5'] }] })
-      expect(items).toHaveLength(1)
-      expect(items[0]).toHaveProperty('name', usr)
+    test('should match resources where desired = 0', async () => {
+      const items = await resolveSearchItems(user.token, { filters: [{ property: 'desired', values: ['=0'] }] })
+      expect(items).toHaveLength(2)
+      const kinds = items.map((i) => i.kind)
+      expect(kinds).toEqual(expect.arrayContaining(['Deployment', 'ReplicaSet']))
     })
 
-    test('should match resources where current > 3', async () => {
+    // TODO: Skiping because this depends on kubernetes creating the pod, which could cause intermittent test failures.
+    test.skip('should match resources where current > 3', async () => {
       const items = await resolveSearchItems(user.token, { filters: [{ property: 'current', values: ['>3'] }] })
       expect(items).toHaveLength(2)
       const kinds = items.map((i) => i.kind)
@@ -161,16 +161,18 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
 
     test('should match deployments where desired <= 5', async () => {
       const items = await resolveSearchItems(user.token, { filters: [{ property: 'desired', values: ['<=5'] }] })
-      expect(items).toHaveLength(3)
+      expect(items).toHaveLength(2)
     })
 
-    test('should match resources where current >= 5', async () => {
+    // TODO: Skiping because this depends on kubernetes creating the pod, which could cause intermittent test failures.
+    test.skip('should match resources where current >= 5', async () => {
       const items = await resolveSearchItems(user.token, { filters: [{ property: 'current', values: ['>=5'] }] })
       expect(items).toHaveLength(1)
       expect(items[0]).toHaveProperty('kind', 'Deployment')
     })
 
-    test('should match resources where kind is not namespace and status is not Running', async () => {
+    // TODO: Skiping because this depends on kubernetes creating the pod, which could cause intermittent test failures.
+    test.skip('should match resources where kind is not namespace and status is not Running', async () => {
       const items = await resolveSearchItems(user.token, {
         filters: [
           { property: 'kind', values: ['!Namespace'] },


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/25902

### Change
- Test must not depend on kubernetes creating pod resources because it may cause tests to fail intermittently.
- Remove Redisgraph deployment.