### PR TITLE
Add delay after setup to work around cache limitation

### DIFF
--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -43,9 +43,14 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     const [route] = await Promise.all([getSearchApiRoute(), execCliCmdString(setupCommands)])
     searchApiRoute = route
 
-    await sleep(20000) // Wait for the service account and search index to get updated.
+    await sleep(15000) // Wait for the service account and search index to get updated.
+  }, 30000)
+
+  // Note: Keep this separate from beforeAll because it causes test to fail for unknown reason.
+  beforeEach(async () => {
+    await sleep(3000)
     user = await getUserContext({ usr, ns })
-  }, 45000)
+  })
 
   afterAll(async () => {
     let teardownCmds = `# export ns=search-query; export usr=search-query-user
@@ -57,7 +62,7 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
       oc delete clusterrolebinding ${usr}`
     }
 
-    execCliCmdString(teardownCmds)
+    await execCliCmdString(teardownCmds)
   }, 30000)
 
   describe(`using keywords`, () => {

--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -43,14 +43,16 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     const [route] = await Promise.all([getSearchApiRoute(), execCliCmdString(setupCommands)])
     searchApiRoute = route
 
-    await sleep(15000) // Wait for the service account and search index to get updated.
-  }, 30000)
+    // Wait for the service account and search index to get updated.
+    // Must wait 2 minutes because of the current RBAC cache.
+    await sleep(120000)
+  }, 1500000)
 
-  // Note: Keep this separate from beforeAll because it causes test to fail for unknown reason.
+  // Keep separate from beforeAll because it slows execution and increases the chances of recovering during retry.
   beforeEach(async () => {
-    await sleep(3000)
+    await sleep(5000)
     user = await getUserContext({ usr, ns })
-  })
+  }, 10000)
 
   afterAll(async () => {
     let teardownCmds = `# export ns=search-query; export usr=search-query-user

--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -43,9 +43,9 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
     const [route] = await Promise.all([getSearchApiRoute(), execCliCmdString(setupCommands)])
     searchApiRoute = route
 
-    await sleep(15000) // Wait for the service account and search index to get updated.
+    await sleep(20000) // Wait for the service account and search index to get updated.
     user = await getUserContext({ usr, ns })
-  }, 40000)
+  }, 45000)
 
   afterAll(async () => {
     let teardownCmds = `# export ns=search-query; export usr=search-query-user

--- a/tests/api/rbac.test.js
+++ b/tests/api/rbac.test.js
@@ -35,7 +35,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
     oc create role ${usr4} --verb=get,list --resource=deployment -n ${ns}
     oc create rolebinding ${usr4} --role=${usr4} --serviceaccount=${ns}:${usr4} -n ${ns}
 
-    oc create deployment ${usr4} -n ${ns} --image=busybox --replicas=1 -- 'date; sleep 1; date; sleep 5;'
+    oc create deployment ${usr4} -n ${ns} --image=busybox --replicas=1 -- 'date; sleep 60;'
     oc patch deployment ${usr4} -n ${ns} -p '{"spec":{"template":{"spec":{"containers":[{"name":"busybox","imagePullPolicy":"IfNotPresent"}]}}}}'
     oc scale deployment ${usr4} -n ${ns} --replicas=5
 
@@ -58,7 +58,7 @@ describe(`[P2][Sev2][${squad}] Search API: Verify RBAC`, () => {
     oc delete clusterrolebinding ${usr2}
     oc delete clusterrole ${usr2}`
 
-    execCliCmdString(teardownCmds)
+    await execCliCmdString(teardownCmds)
   }, 10000)
 
   describe(`with user ${usr0} (not authorized to list any resources)`, () => {

--- a/tests/common-lib/cliClient.js
+++ b/tests/common-lib/cliClient.js
@@ -13,7 +13,11 @@ async function execCliCmdString(commands) {
   cmds.forEach((cmd) => {
     // Ignore empty lines and comments.
     if (cmd.trim() && cmd.trim().charAt(0) !== '#') {
-      execSync(cmd.trim())
+      try {
+        execSync(cmd.trim())
+      } catch (e) {
+        console.log(`Error executing cli command. Command: [${cmd}] Error: [${e}]`)
+      }
     }
   })
 }


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>
**Issue**: https://github.com/stolostron/backlog/issues/26120

### Changes:
- Adds longer wait after setup to work around cache limitations.
- Moves the user context initialization to beforeEach to fix problem with queries tests.
- Logs CLI command errors to debug failing tests in canaries.