### PR TITLE
Update oc cli to 4.11.12

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -6,7 +6,7 @@ mkdir clis-unpacked
 
 # Install OpenShift and Kubectl CLI.
 echo 'Installing oc and kubectl clis...'
-curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.11.3/openshift-client-linux-4.11.3.tar.gz
+curl -kLo oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.11.12/openshift-client-linux-4.11.12.tar.gz
 tar -xzf oc.tar.gz -C clis-unpacked
 chmod 755 ./clis-unpacked/oc
 chmod 755 ./clis-unpacked/kubectl


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/26636

Updating because I was having problems with `oc` 4.11.3 in my dev laptop. These looked similar to the login problems I see in the latest canary.