### PR TITLE
Overview static query should use capitalized kind value

### DIFF
--- a/tests/cypress/views/overview.js
+++ b/tests/cypress/views/overview.js
@@ -54,7 +54,7 @@ export const overviewPage = {
         }
       })
 
-    cy.get('.pf-c-chip-group__list').should('have.length', 1).invoke('text').should('eq', 'kind:cluster')
+    cy.get('.pf-c-chip-group__list').should('have.length', 1).invoke('text').should('eq', 'kind:Cluster')
 
     searchPage.shouldLoadResults()
     cy.get('.pf-c-expandable-section__toggle-text').filter(':contains(Cluster)')


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issue: https://github.com/stolostron/backlog/issues/27099