### PR TITLE
Rename console tests for consistent reporting

### DIFF
--- a/tests/cypress/tests/detailsPage.spec.js
+++ b/tests/cypress/tests/detailsPage.spec.js
@@ -18,7 +18,7 @@ const clusterMode = {
   valueFn: () => cy.wrap('local-cluster'),
 }
 
-describe(`Search: Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {
+describe(`Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {
   before(function () {
     // Setting the cluster mode cluster as the current instance cluster.
     clusterMode.valueFn().as('clusterName')
@@ -29,7 +29,7 @@ describe(`Search: Search in ${clusterMode.label} Cluster`, { tags: tags.env }, f
     cy.visitAndLogin('/multicloud/home/search')
   })
 
-  context('Verify: search detail pages for yaml and logs', { tags: tags.modes }, function () {
+  context('Console-Search detail pages for yaml and logs', { tags: tags.modes }, function () {
     beforeEach(function () {
       searchPage.shouldFindNamespaceInCluster(clusterMode.namespace, this.clusterName)
     })

--- a/tests/cypress/tests/overview.spec.js
+++ b/tests/cypress/tests/overview.spec.js
@@ -8,13 +8,13 @@
 import { squad, tags } from '../config'
 import { overviewPage } from '../views/overview'
 
-describe('RHACM4K-1419: Search: Overview page', { tags: tags.env }, function () {
+describe('RHACM4K-1419: Overview page', { tags: tags.env }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
     cy.visitAndLogin('/multicloud/home/overview')
   })
 
-  context('UI - Overview page validation', { tags: tags.modes }, function () {
+  context('Console-Overview page validation', { tags: tags.modes }, function () {
     it(`[P1][Sev1][${squad}] should load and render the overview page`, function () {
       overviewPage.shouldLoad()
     })

--- a/tests/cypress/tests/saved-searches.spec.js
+++ b/tests/cypress/tests/saved-searches.spec.js
@@ -17,20 +17,20 @@ const queryDefaultNamespaceDesc = `This is searching that the cluster should hav
 const queryEditNamespaceName = `[E2E] ${namespace}-edit`
 const queryEditNamespaceDesc = `[Created by Search E2E automation] This is searching that the cluster should have ${namespace} namespace.`
 
-describe('RHACM4K-412 - Search: Saved searches', { tags: tags.env }, function () {
+describe('RHACM4K-412 - Saved searches', { tags: tags.env }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
     cy.visitAndLogin('/multicloud/home/search')
   })
 
-  context('verify: saved searches resource actions', { tags: tags.modes }, function () {
+  context('Console-Search saved searches', { tags: tags.modes }, function () {
     it(`[P3][Sev3][${squad}] should verify that the namespace is available`, function () {
       searchBar.whenFilterByNamespace(namespace)
       searchBar.whenRunSearchQuery()
       searchPage.shouldLoadResults()
     })
 
-    it(`[P3][Sev3][${squad}] should be able to save current search`, function () {
+    it(`[P3][Sev3][${squad}] should save current search`, function () {
       savedSearches.saveClusterNamespaceSearch(
         'local-cluster',
         namespace,
@@ -39,23 +39,23 @@ describe('RHACM4K-412 - Search: Saved searches', { tags: tags.env }, function ()
       )
     })
 
-    it(`[P3][Sev3][${squad}] should be able to find the saved search`, function () {
+    it(`[P3][Sev3][${squad}] should find the saved search`, function () {
       savedSearches.getSavedSearch(queryDefaultNamespaceName)
     })
 
-    it(`[P3][Sev3][${squad}] should be able to edit the saved searches`, function () {
+    it(`[P3][Sev3][${squad}] should edit the saved searches`, function () {
       savedSearches.editSavedSearch(namespace, queryEditNamespaceName, queryEditNamespaceDesc)
     })
 
-    it(`[P3][Sev3][${squad}] should be able to revert back the edited saved searches`, function () {
+    it(`[P3][Sev3][${squad}] should revert back the edited saved searches`, function () {
       savedSearches.editSavedSearch(queryEditNamespaceName, queryDefaultNamespaceName, queryDefaultNamespaceDesc)
     })
 
-    it(`[P3][Sev3][${squad}] should be able to share the saved searches`, function () {
+    it(`[P3][Sev3][${squad}] should share the saved searches`, function () {
       savedSearches.shareSavedSearch(queryDefaultNamespaceName)
     })
 
-    it(`[P3][Sev3][${squad}] should be able to delete the saved searches ${queryDefaultNamespaceName}`, function () {
+    it(`[P3][Sev3][${squad}] should delete the saved searches ${queryDefaultNamespaceName}`, function () {
       savedSearches.whenDeleteSavedSearch(queryDefaultNamespaceName)
     })
   })

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -36,7 +36,7 @@ describe(`Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function 
     })
   })
 
-  context('Console-Search verify search results with common filter and condition', { tags: tags.modes }, function () {
+  context('Console-Search verify results with common filter and condition', { tags: tags.modes }, function () {
     beforeEach(function () {
       searchPage.shouldFindNamespaceInCluster(clusterMode.namespace, this.clusterName)
     })

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -16,7 +16,7 @@ const clusterMode = {
   valueFn: () => cy.wrap('local-cluster'),
 }
 
-describe(`Search: Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {
+describe(`Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {
   before(function () {
     // Setting the cluster mode cluster as the current instance cluster.
     clusterMode.valueFn().as('clusterName')
@@ -27,7 +27,7 @@ describe(`Search: Search in ${clusterMode.label} Cluster`, { tags: tags.env }, f
     cy.visitAndLogin('/multicloud/home/search')
   })
 
-  context('UI - Search page validation', { tags: tags.modes }, function () {
+  context('Console-Search page validation', { tags: tags.modes }, function () {
     it(`[P1][Sev1][${squad}] should load and render the search page`, function () {
       searchPage.shouldLoad()
       searchPage.shouldRenderSavedSearchesTab()
@@ -36,7 +36,7 @@ describe(`Search: Search in ${clusterMode.label} Cluster`, { tags: tags.env }, f
     })
   })
 
-  context('Verify: search results with common filter and condition', { tags: tags.modes }, function () {
+  context('Console-Search verify search results with common filter and condition', { tags: tags.modes }, function () {
     beforeEach(function () {
       searchPage.shouldFindNamespaceInCluster(clusterMode.namespace, this.clusterName)
     })

--- a/tests/cypress/tests/suggested-searches.spec.js
+++ b/tests/cypress/tests/suggested-searches.spec.js
@@ -9,13 +9,13 @@ import { squad, tags } from '../config'
 import { searchBar } from '../views/search'
 import { suggestedSearches } from '../views/suggestedSearches'
 
-describe('RHACM4K-411: Search: Verify the suggested search templates', { tags: tags.env }, function () {
+describe('RHACM4K-411: Verify the suggested search templates', { tags: tags.env }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
     cy.visitAndLogin('/multicloud/home/search')
   })
 
-  context('verify: search page suggested search queries', { tags: tags.modes }, function () {
+  context('Console-Search suggested searches', { tags: tags.modes }, function () {
     it(`[P3][Sev3][${squad}] should see the workloads template & search tag in search items`, function () {
       suggestedSearches.whenSelectCardWithTitle('Workloads')
       searchBar.shouldContainTag('kind:DaemonSet,Deployment,Job,StatefulSet,ReplicaSet')


### PR DESCRIPTION
Update the cypress tests to produce better and consistent reports.

Before changes
<img width="798" alt="image" src="https://github.com/stolostron/search-e2e-test/assets/4671325/23b3f76a-810c-4c28-8286-a8f07aede6ae">
