### PR TITLE
Update overview test to only test fleet view page

### DIFF
--- a/tests/cypress/tests/overview.spec.js
+++ b/tests/cypress/tests/overview.spec.js
@@ -17,16 +17,21 @@ describe('RHACM4K-1419: Overview page', { tags: tags.env }, function () {
       overviewPage.shouldLoad()
     })
 
-    it(`[P2][Sev2][${squad}] should have clusters provider card`, function () {
-      overviewPage.shouldHaveClusterProviderCard()
+    it(`[P2][Sev2][${squad}] should have fleet summary section`, function () {
+      overviewPage.shouldHaveSummarySection()
     })
 
-    it(`[P2][Sev2][${squad}] should have clusters summary breakdown`, function () {
-      overviewPage.shouldHaveClusterSummary()
+    it(`[P2][Sev2][${squad}] should have insights section`, function () {
+      overviewPage.shouldHaveInsightsSection()
     })
 
-    it(`[P2][Sev2][${squad}] should have link to search page`, function () {
-      overviewPage.shouldHaveLinkToSearchPage()
+    it(`[P2][Sev2][${squad}] should have cluster health section`, function () {
+      overviewPage.shouldHaveClusterHealthSection()
     })
+
+    // Implement once there are saved searches in env.
+    // it(`[P2][Sev2][${squad}] should have saved search section`, function () {
+    //   overviewPage.shouldHaveSavedSearchSection()
+    // })
   })
 })

--- a/tests/cypress/tests/resourceDetailsPage.spec.js
+++ b/tests/cypress/tests/resourceDetailsPage.spec.js
@@ -23,7 +23,7 @@ describe(`Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function 
 
   beforeEach(function () {
     // Log into the cluster ACM console.
-    cy.visitAndLogin('/multicloud/home/search')
+    cy.visitAndLogin('/multicloud/search')
   })
 
   context('Console-Search detail pages for yaml and logs', { tags: tags.modes }, function () {

--- a/tests/cypress/tests/saved-searches.spec.js
+++ b/tests/cypress/tests/saved-searches.spec.js
@@ -18,7 +18,7 @@ const queryEditNamespaceDesc = `[Created by Search E2E automation] This is searc
 describe('RHACM4K-412 - Saved searches', { tags: tags.env }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
-    cy.visitAndLogin('/multicloud/home/search')
+    cy.visitAndLogin('/multicloud/search')
   })
 
   context('Console-Search saved searches', { tags: tags.modes }, function () {

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -22,7 +22,7 @@ describe(`Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function 
 
   beforeEach(function () {
     // Log into the cluster ACM console.
-    cy.visitAndLogin('/multicloud/home/search')
+    cy.visitAndLogin('/multicloud/search')
   })
 
   context('Console-Search page validation', { tags: tags.modes }, function () {

--- a/tests/cypress/tests/suggested-searches.spec.js
+++ b/tests/cypress/tests/suggested-searches.spec.js
@@ -10,7 +10,7 @@ import { suggestedSearches } from '../views/suggestedSearches'
 describe('RHACM4K-411: Verify the suggested search templates', { tags: tags.env }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
-    cy.visitAndLogin('/multicloud/home/search')
+    cy.visitAndLogin('/multicloud/search')
   })
 
   context('Console-Search suggested searches', { tags: tags.modes }, function () {

--- a/tests/cypress/views/overview.js
+++ b/tests/cypress/views/overview.js
@@ -3,8 +3,6 @@
  * Copyright (c) 2021 Red Hat, Inc.
  ****************************************************************************** */
 
-import { searchPage } from '../views/search'
-
 /**
  * Overview page object for the ACM console.
  */
@@ -17,50 +15,110 @@ export const overviewPage = {
     cy.get('.pf-c-skeleton').should('not.exist')
     cy.get('h1.pf-c-title').filter(':contains(Overview)').should('exist')
   },
+
   /**
-   * Verify that the Overview page should have a cluster provider card panel.
+   * Verify the Overview page should correctly display summary section.
+   * TODO - verify data & links
    */
-  shouldHaveClusterProviderCard: () => {
-    cy.get('.pf-l-gallery.pf-m-gutter').find('.pf-c-card.pf-m-selectable').should('exist')
-    cy.get('.pf-c-card__footer').should('exist').and('contain', 'Cluster')
-  },
-  /**
-   * Verify that the Overview page should have a summary of the test cluster environment.
-   */
-  shouldHaveClusterSummary: () => {
-    cy.get('article.pf-c-card')
-      .filter(':contains(Summary)')
+  shouldHaveSummarySection: () => {
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Clusters)')
       .should('exist')
+      .next()
       .within(() => {
-        cy.get('.pf-c-card__body').should('contain', 'Application').and('contain', 'Cluster').and('contain', 'Nodes')
+        cy.get('tspan').should('contain', 'total clusters')
+      })
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Application types)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('span').should('contain', 'total applications')
+      })
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Policies)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('span').should('contain', 'enabled policies')
+      })
+
+    cy.get('div.pf-c-card__title').filter(':contains(Cluster version)').should('exist')
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Nodes)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('span').should('contain', 'total nodes')
+      })
+
+    cy.get('div.pf-c-card__title').filter(':contains(Worker core count)').should('exist')
+  },
+
+  /**
+   * Verify the Overview page should display insights section.
+   * TODO - verify data & links
+   */
+  shouldHaveInsightsSection: () => {
+    cy.get('div.pf-c-card__title').filter(':contains(Insights)').should('exist')
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Cluster recommendations)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('span').should('contain', 'clusters affected')
+      })
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Update risk predictions)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('span').should('contain', 'clusters need to be reviewed before updating')
       })
   },
-  /**
-   * Verify that the Overview page should have accessible links to the Search page.
-   */
-  shouldHaveLinkToSearchPage: () => {
-    cy.get('#clusters-summary a')
-      .should('exist')
-      .and('be.visible')
-      .then((clusters) => {
-        const numOfCluster = clusters.text()
 
-        if (numOfCluster > 0) {
-          cy.wrap(clusters).click()
-        } else {
-          cy.log(`${numOfCluster} detected within the overview cluster summary`)
-        }
+  /**
+   * Verify the Overview page should display cluster health section.
+   * TODO - verify data & links
+   */
+  shouldHaveClusterHealthSection: () => {
+    cy.get('div.pf-c-card__title').filter(':contains(Cluster health)').should('exist')
+
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Status)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('tspan').should('contain', 'Ready')
       })
 
-    cy.get('.pf-c-chip-group__list').should('have.length', 1).invoke('text').should('eq', 'kind:Cluster')
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Violations)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('tspan').should('contain', 'No violations')
+      })
 
-    searchPage.shouldLoadResults()
-    cy.get('.pf-c-accordion__toggle-text').filter(':contains(Cluster)')
-    cy.go('back')
+    cy.get('div.pf-c-card__title')
+      .filter(':contains(Cluster add-ons)')
+      .should('exist')
+      .next()
+      .within(() => {
+        cy.get('tspan').should('contain', 'Available')
+      })
+  },
 
-    cy.get('#nodes-summary a').should('exist').and('be.visible').click()
-
-    searchPage.shouldLoadResults()
-    cy.get('.pf-c-accordion__toggle-text').filter(':contains(Node)')
+  /**
+   * Verify the Overview page should display the saved search section.
+   * TODO - verify data & links once saved searches are populated in env.
+   */
+  shouldHaveSavedSearchSection: () => {
+    cy.get('div.pf-c-card__title').filter(':contains(Your view)').should('exist')
   },
 }

--- a/tests/cypress/views/savedSearches.js
+++ b/tests/cypress/views/savedSearches.js
@@ -37,7 +37,7 @@ export const savedSearches = {
     cy.get('.pf-c-dropdown__menu.pf-m-align-right').contains('Share').click()
     cy.get('input.pf-c-form-control')
       .invoke('val')
-      .then((inputText) => inputText.includes('/multicloud/home/search?filters={"textsearch"'))
+      .then((inputText) => inputText.includes('/multicloud/search?filters={"textsearch"'))
   },
   shouldExist: (queryName) => {
     cy.get('h4.pf-c-title.pf-m-md').should('contain', 'Saved searches').should('exist')


### PR DESCRIPTION
classic overview page is now removed from ACM (2.13). This updates the overview test to test against the fleet view page.
The first implementation only tests for page components rendering properly. Not the data.

Also updates the search route `/multicloud/home/search` -> `/multicloud/search`