### PR TITLE
Reduce intermittent failures

### DIFF
--- a/tests/api/managed.test.js
+++ b/tests/api/managed.test.js
@@ -30,16 +30,14 @@ describe('RHACM4K-1695: Search - verify managed cluster info in the search page'
       query = searchQueryBuilder({
         filters: [
           { property: 'cluster', values: ['!local-cluster'] },
-          { property: 'kind', values: ['pod'] },
+          { property: 'kind', values: ['Pod'] },
           { property: 'namespace', values: ['open-cluster-management-agent'] },
         ],
       })
       res = await sendRequest(query, token)
 
       var pods = _.get(res, 'body.data.searchResult[0].items', [])
-      pods.forEach((element) => {
-        expect(element.status).toEqual('Running')
-      })
+      expect(pods.length).toBeGreaterThan(0)
     } else {
       console.log('Test skipped because no managedCluster detected.')
     }


### PR DESCRIPTION
Issue: https://github.com/stolostron/backlog/issues/27726

In this test the actual pod states are not relevant, we just want to confirm that our search index has some data. Test is failing intermittently when we encounter pods that aren't in running state.