### PR TITLE
ACM-18757 add longer period for queries tests resources to be indexed

### DIFF
--- a/tests/api/queries.test.js
+++ b/tests/api/queries.test.js
@@ -36,7 +36,8 @@ describe(`[P3][Sev3][${squad}] Search API - Verify results of different queries`
 
     // Wait for the service account and search index to get updated.
     // Must wait 2 minutes because of the current RBAC cache.
-    await sleep(120000)
+    // another 1 minute grace period added to ensure resources indexed
+    await sleep(120000 + 60000)
   }, 1500000)
 
   // Keep separate from beforeAll because it slows execution and increases the chances of recovering during retry.


### PR DESCRIPTION
https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_canary_api_tests/119/
https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_canary_api_tests/118/
both failed presumably due to the resources not yet  being indexed. Increasing the wait time from 2 minutes to 3 minutes should be adequate for resources to be indexed.

This could be handled differently and better if this resolves the problem. e.g. moving this additional wait to after the first failure of tests before the next retry.