### PR TITLE
permit customizable ocm namespace names

### DIFF
--- a/resources/options.yaml.template
+++ b/resources/options.yaml.template
@@ -1,6 +1,7 @@
 options:
   identityProvider: BASE_OC_IDP
   hub:
+    acmNamespace: ACM_NAMESPACE
     baseDomain: BASE_DOMAIN
     user: BASE_USER
     password: BASE_PASSWORD


### PR DESCRIPTION
Sometimes automation is triggered with namespace set as "ocm", our Search DB check assumes "open-cluster-management". This accepts a custom namespace and will default to "open-cluster-management" if not set.