### PR TITLE
normalize CYPRESS_BASE_URL

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -116,7 +116,12 @@ export CYPRESS_OPTIONS_HUB_PASSWORD=$OPTIONS_HUB_PASSWORD
 export CYPRESS_OPTIONS_HUB_USER=$OPTIONS_HUB_USER
 
 # Export base url for cluster.
-export BASE_URL=https://console-openshift-console.apps.$OPTIONS_HUB_BASEDOMAIN
+normalized_url=$OPTIONS_HUB_BASEDOMAIN
+# Remove https://api. if present
+normalized_url="${normalized_url#https://api.}"
+# Remove :6443 if present
+normalized_url="${normalized_url%:6443}"
+export BASE_URL=https://console-openshift-console.apps.$normalized_url
 export CYPRESS_BASE_URL=$BASE_URL
 
 echo -e


### PR DESCRIPTION
OPTIONS_HUB_BASEDOMAIN passed in the format from Jenkins automation like `https://api.sno-...com:6443` gets appended and used improperly in cypress testing later. OPTIONS_HUB_BASEDOMAIN passed via prow automation like `sno...com` works. This normalizes that. See:
```
Cypress could not verify that this server is running:

  > https://console-openshift-console.apps.https://api.sno-....com:6443

We are verifying this server because it has been configured as your baseUrl.

Cypress automatically waits until your server is accessible before running tests.

We will try connecting to it 3 more times...
We will try connecting to it 2 more times...
We will try connecting to it 1 more time...

Cypress failed to verify that your server is running.
```