### PR TITLE
electron browser support for regression testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         string(name: 'OCP_HUB_CLUSTER_PASSWORD', defaultValue: '', description: 'OCP Hub Password. (Required)')
         string(name: 'OCP_HUB_CLUSTER_API_URL', defaultValue: '', description: 'OCP Hub API URL. (Required)')
         string(name: 'ACM_NAMESPACE', defaultValue: 'ocm', description: 'The Namespace in which ACM is installed. Default is ocm')
-        choice(name: 'BROWSER', choices: ['chrome', 'firefox', 'edge'], description:'Browser type. e.g. chrome, firefox, edge')
+        choice(name: 'BROWSER', choices: ['chrome', 'firefox', 'edge', 'electron'], description:'Browser type. e.g. chrome, firefox, edge')
         choice(name: 'SKIP_API_TEST', choices: ['false','true'], description: 'Flag to skip the API tests')
         choice(name: 'SKIP_UI_TEST', choices: ['false','true'], description: 'Flag to skip the UI tests')
         string(name: 'GIT_BRANCH', defaultValue: 'main', description: 'The GIT branch for CLC to checkout')


### PR DESCRIPTION
Regression failed to trigger because electron was missing from browser choices: https://redhat-internal.slack.com/archives/C07UZ4XMGCW/p1758210752086549?thread_ts=1758210280.392679&cid=C07UZ4XMGCW