### PR TITLE
[release-2.14] make acm namespace env var accessible to tests (#429)

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -358,6 +358,11 @@ if [[ "$SKIP_API_TEST" == "false" || "$SKIP_UI_TEST" == "false" ]]; then
   done
 fi
 
+if [[ -z $ACM_NAMESPACE || "$ACM_NAMESPACE" == "null" ]]; then
+  ACM_NAMESPACE="open-cluster-management"
+fi
+export CYPRESS_ACM_NAMESPACE=$ACM_NAMESPACE
+
 if [[ "$SKIP_API_TEST" == false ]]; then 
   log_color "cyan" "Running Search API tests."
 

--- a/tests/api/common.test.js
+++ b/tests/api/common.test.js
@@ -7,6 +7,7 @@ const { getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterA
 const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient')
 
 const _ = require('lodash')
+const acmNamespace = process.env.CYPRESS_ACM_NAMESPACE
 
 describe('RHACM4K-1696: Search API - Verify search result with common filter and conditions', () => {
   beforeAll(async () => {
@@ -31,11 +32,11 @@ describe('RHACM4K-1696: Search API - Verify search result with common filter and
     expect(res.body.data.searchResult[0].items[0].namespace).toEqual('openshift-console')
   }, 20000)
 
-  test(`[P2][Sev2][${squad}] with query {kind:Pod status:Running namespace:open-cluster-management}`, async () => {
+  test(`[P2][Sev2][${squad}] with query {kind:Pod status:Running namespace:${acmNamespace}}`, async () => {
     var query = searchQueryBuilder({
       filters: [
         { property: 'kind', values: ['Pod'] },
-        { property: 'namespace', values: ['open-cluster-management'] },
+        { property: 'namespace', values: [acmNamespace] },
         { property: 'status', values: ['Running'] },
       ],
     })

--- a/tests/cypress/tests/resourceDetailsPage.spec.js
+++ b/tests/cypress/tests/resourceDetailsPage.spec.js
@@ -10,7 +10,7 @@ import { searchBar, searchPage } from '../views/search'
 const clusterMode = {
   deployment: 'search-api',
   label: 'Local',
-  namespace: 'open-cluster-management',
+  namespace: Cypress.env('ACM_NAMESPACE'),
   skip: false,
   valueFn: () => cy.wrap('local-cluster'),
 }

--- a/tests/cypress/tests/saved-searches.spec.js
+++ b/tests/cypress/tests/saved-searches.spec.js
@@ -7,7 +7,7 @@ import { squad, tags } from '../config'
 import { savedSearches } from '../views/savedSearches'
 import { searchBar, searchPage } from '../views/search'
 
-const namespace = 'open-cluster-management'
+const namespace = Cypress.env('ACM_NAMESPACE')
 
 const queryDefaultNamespaceName = `${namespace}-default`
 const queryDefaultNamespaceDesc = `This is searching that the cluster should have ${namespace} namespace.`

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -9,7 +9,7 @@ import { searchBar, searchPage } from '../views/search'
 const clusterMode = {
   deployment: 'search-api',
   label: 'Local',
-  namespace: 'open-cluster-management',
+  namespace: Cypress.env('ACM_NAMESPACE'),
   skip: false,
   valueFn: () => cy.wrap('local-cluster'),
 }


### PR DESCRIPTION
cherry-pick of https://github.com/stolostron/search-e2e-test/pull/429