### PR TITLE
Rosa route handling

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -116,22 +116,14 @@ export CYPRESS_OPTIONS_HUB_PASSWORD=$OPTIONS_HUB_PASSWORD
 export CYPRESS_OPTIONS_HUB_USER=$OPTIONS_HUB_USER
 
 # Export base url for cluster.
-# Query the actual console route instead of constructing it to handle ROSA HCP and other cluster types
-CONSOLE_ROUTE=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}' 2>/dev/null)
-if [[ -z $CONSOLE_ROUTE ]]; then
-  log_color "yellow" "Could not query console route, falling back to URL construction"
-  normalized_url=$OPTIONS_HUB_BASEDOMAIN
-  # Remove https://api. if present
-  normalized_url="${normalized_url#https://api.}"
-  # Remove :6443 if present
-  normalized_url="${normalized_url%:6443}"
-  # Remove :443 if present
-  normalized_url="${normalized_url%:443}"
-  export BASE_URL=https://console-openshift-console.apps.$normalized_url
-else
-  export BASE_URL=https://$CONSOLE_ROUTE
-  log_color "green" "Detected console route: $BASE_URL"
-fi
+normalized_url=$OPTIONS_HUB_BASEDOMAIN
+# Remove https://api. if present
+normalized_url="${normalized_url#https://api.}"
+# Remove :6443 if present
+normalized_url="${normalized_url%:6443}"
+# Remove :443 if present
+normalized_url="${normalized_url%:443}"
+export BASE_URL=https://console-openshift-console.apps.$normalized_url
 export CYPRESS_BASE_URL=$BASE_URL
 
 echo -e
@@ -171,6 +163,16 @@ if [[ ! -z $CYPRESS_OPTIONS_HUB_PASSWORD && "$CYPRESS_OPTIONS_HUB_PASSWORD" != "
 fi
 
 echo -e "Logged in as user: $(oc whoami)\n"
+
+# Query the actual console route instead of constructing it to handle ROSA HCP and other cluster types
+CONSOLE_ROUTE=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -n $CONSOLE_ROUTE ]]; then
+  export BASE_URL=https://$CONSOLE_ROUTE
+  export CYPRESS_BASE_URL=$BASE_URL
+  log_color "green" "Detected console route: $BASE_URL\n"
+else
+  log_color "yellow" "Could not query console route, using constructed URL: $BASE_URL\n"
+fi
 
 export CYPRESS_ACM_VERSION=`oc get subscriptions.operators.coreos.com -A -o yaml | grep currentCSV:\ advanced-cluster-management | awk '{$1=$1};1' | sed "s/currentCSV:\ advanced-cluster-management.v//"`
 log_color "green" "Testing with ACM Version": "$CYPRESS_ACM_VERSION\n"

--- a/start-tests.sh
+++ b/start-tests.sh
@@ -116,14 +116,22 @@ export CYPRESS_OPTIONS_HUB_PASSWORD=$OPTIONS_HUB_PASSWORD
 export CYPRESS_OPTIONS_HUB_USER=$OPTIONS_HUB_USER
 
 # Export base url for cluster.
-normalized_url=$OPTIONS_HUB_BASEDOMAIN
-# Remove https://api. if present
-normalized_url="${normalized_url#https://api.}"
-# Remove :6443 if present
-normalized_url="${normalized_url%:6443}"
-# Remove :443 if present
-normalized_url="${normalized_url%:443}"
-export BASE_URL=https://console-openshift-console.apps.$normalized_url
+# Query the actual console route instead of constructing it to handle ROSA HCP and other cluster types
+CONSOLE_ROUTE=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}' 2>/dev/null)
+if [[ -z $CONSOLE_ROUTE ]]; then
+  log_color "yellow" "Could not query console route, falling back to URL construction"
+  normalized_url=$OPTIONS_HUB_BASEDOMAIN
+  # Remove https://api. if present
+  normalized_url="${normalized_url#https://api.}"
+  # Remove :6443 if present
+  normalized_url="${normalized_url%:6443}"
+  # Remove :443 if present
+  normalized_url="${normalized_url%:443}"
+  export BASE_URL=https://console-openshift-console.apps.$normalized_url
+else
+  export BASE_URL=https://$CONSOLE_ROUTE
+  log_color "green" "Detected console route: $BASE_URL"
+fi
 export CYPRESS_BASE_URL=$BASE_URL
 
 echo -e


### PR DESCRIPTION
Latest UI Cypress run against ROSA cluster failed because the console route Cypress used to verify the server was running was missing a `.rosa` subdomain. We fetch the proper URL from getting the route. https://redhat-internal.slack.com/archives/C0804HR2D41/p1774890605407419?thread_ts=1774890053.715339&cid=C0804HR2D41

Broken run: https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_tests/210/console
Happy run: https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_tests/213/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test configuration by implementing automatic detection of the OpenShift console environment endpoint, with graceful fallback to previously configured values if detection is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->