### PR TITLE
ACM-27856: Add e2e tests for wildcard (*) subscription filter support

### DIFF
--- a/tests/api/subscription-wildcard.test.js
+++ b/tests/api/subscription-wildcard.test.js
@@ -1,0 +1,253 @@
+// Copyright Contributors to the Open Cluster Management project
+
+// Test wildcard (*) support in streaming subscription filters (ACM-27856).
+// PR: https://github.com/stolostron/search-v2-api/pull/704
+
+const squad = require('../../config').get('squadName')
+
+const { execCliCmdString } = require('../common-lib/cliClient')
+const { getKubeadminToken, getSearchApiRoute } = require('../common-lib/clusterAccess')
+const { createWebSocket } = require('../common-lib/websocketHelper')
+
+let token = ''
+let websocketUrl = ''
+
+const WATCH_QUERY =
+  'subscription watch($input: SearchInput) { watch(input: $input) { uid operation newData oldData timestamp } }'
+const TEST_TIMEOUT = 15000
+
+function buildSubscribeMsg(id, filters) {
+  return JSON.stringify({
+    id,
+    type: 'subscribe',
+    payload: {
+      query: WATCH_QUERY,
+      variables: { input: { keywords: [], filters } },
+      operationName: 'watch',
+    },
+  })
+}
+
+async function waitFor(condition, timeoutMs = 10000, intervalMs = 50) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) return false
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  return true
+}
+
+describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Support`, () => {
+  beforeAll(async () => {
+    token = getKubeadminToken()
+    const searchApiRoute = await getSearchApiRoute()
+    websocketUrl = searchApiRoute.replace('https://', 'wss://')
+  })
+
+  afterAll(async () => {
+    await execCliCmdString(`
+      oc delete configmap test-wc-alpha -n default --ignore-not-found
+      oc delete configmap test-wc-beta -n default --ignore-not-found
+      oc delete configmap test-wc-other -n default --ignore-not-found
+      oc delete configmap wc-suffix-test -n default --ignore-not-found
+      oc delete configmap wc-contains-wildcard-cm -n default --ignore-not-found
+      oc delete configmap wc-kind-test -n default --ignore-not-found
+      oc delete configmap wc-case-test -n default --ignore-not-found
+    `)
+  })
+
+  it(
+    'should receive events matching a prefix wildcard filter on name (test-wc-*)',
+    async () => {
+      let matchCount = 0
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        if (
+          eventData.type === 'next' &&
+          event.data.includes('INSERT') &&
+          (event.data.includes('test-wc-alpha') || event.data.includes('test-wc-beta'))
+        ) {
+          matchCount++
+        }
+      }
+
+      ws.send(
+        buildSubscribeMsg('wc-0001', [
+          { property: 'kind', values: ['ConfigMap'] },
+          { property: 'name', values: ['test-wc-*'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      await execCliCmdString('oc create configmap test-wc-alpha -n default')
+      await execCliCmdString('oc create configmap test-wc-beta -n default')
+
+      const received = await waitFor(() => matchCount >= 2)
+      expect(received).toBe(true)
+      expect(matchCount).toBeGreaterThanOrEqual(2)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'should NOT receive events for resources that do not match the wildcard filter',
+    async () => {
+      let gotUnexpected = false
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        // Subscribe to 'prefix-wc-*' — 'test-wc-other' should not match.
+        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('test-wc-other')) {
+          gotUnexpected = true
+        }
+      }
+
+      ws.send(
+        buildSubscribeMsg('wc-0002', [
+          { property: 'kind', values: ['ConfigMap'] },
+          { property: 'name', values: ['prefix-wc-*'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await execCliCmdString('oc create configmap test-wc-other -n default')
+
+      // Wait long enough to confirm no matching event is delivered.
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      expect(gotUnexpected).toBe(false)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'should receive events matching a suffix wildcard filter on name (*-test)',
+    async () => {
+      let gotMatch = false
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-suffix-test')) {
+          gotMatch = true
+        }
+      }
+
+      ws.send(
+        buildSubscribeMsg('wc-0003', [
+          { property: 'kind', values: ['ConfigMap'] },
+          { property: 'name', values: ['*-test'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await execCliCmdString('oc create configmap wc-suffix-test -n default')
+
+      const received = await waitFor(() => gotMatch)
+      expect(received).toBe(true)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'should receive events matching a contains wildcard filter on name (*wildcard*)',
+    async () => {
+      let gotMatch = false
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        if (
+          eventData.type === 'next' &&
+          event.data.includes('INSERT') &&
+          event.data.includes('wc-contains-wildcard-cm')
+        ) {
+          gotMatch = true
+        }
+      }
+
+      ws.send(
+        buildSubscribeMsg('wc-0004', [
+          { property: 'kind', values: ['ConfigMap'] },
+          { property: 'name', values: ['*wildcard*'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await execCliCmdString('oc create configmap wc-contains-wildcard-cm -n default')
+
+      const received = await waitFor(() => gotMatch)
+      expect(received).toBe(true)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'should receive events when kind filter uses a wildcard (ConfigMap*)',
+    async () => {
+      let gotMatch = false
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-kind-test')) {
+          gotMatch = true
+        }
+      }
+
+      ws.send(
+        buildSubscribeMsg('wc-0005', [
+          { property: 'kind', values: ['ConfigMap*'] },
+          { property: 'name', values: ['wc-kind-test'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await execCliCmdString('oc create configmap wc-kind-test -n default')
+
+      const received = await waitFor(() => gotMatch)
+      expect(received).toBe(true)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+
+  it(
+    'wildcard matching is case-sensitive: configmap* should NOT match kind=ConfigMap',
+    async () => {
+      let gotMatch = false
+      const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
+
+      ws.onmessage = (event) => {
+        const eventData = JSON.parse(event.data)
+        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-case-test')) {
+          gotMatch = true
+        }
+      }
+
+      // 'configmap*' (all lowercase) should NOT match kind 'ConfigMap' (mixed case).
+      ws.send(
+        buildSubscribeMsg('wc-0006', [
+          { property: 'kind', values: ['configmap*'] },
+          { property: 'name', values: ['wc-case-test'] },
+        ])
+      )
+
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      await execCliCmdString('oc create configmap wc-case-test -n default')
+
+      // Wait to confirm no event arrives for the case-mismatched filter.
+      await new Promise((resolve) => setTimeout(resolve, 3000))
+      expect(gotMatch).toBe(false)
+      ws.close()
+    },
+    TEST_TIMEOUT
+  )
+})

--- a/tests/api/subscription-wildcard.test.js
+++ b/tests/api/subscription-wildcard.test.js
@@ -51,34 +51,37 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let matchCount = 0
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        if (
-          eventData.type === 'next' &&
-          event.data.includes('INSERT') &&
-          (event.data.includes('test-wc-alpha') || event.data.includes('test-wc-beta'))
-        ) {
-          matchCount++
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          if (
+            eventData.type === 'next' &&
+            event.data.includes('INSERT') &&
+            (event.data.includes('test-wc-alpha') || event.data.includes('test-wc-beta'))
+          ) {
+            matchCount++
+          }
         }
+
+        ws.send(
+          buildSubscribeMsg('wc-0001', [
+            { property: 'kind', values: ['ConfigMap'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['test-wc-*'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        await execCliCmdString(`oc create configmap test-wc-alpha -n ${testNamespace}`)
+        await execCliCmdString(`oc create configmap test-wc-beta -n ${testNamespace}`)
+
+        const received = await waitFor(() => matchCount >= 2)
+        expect(received).toBe(true)
+        expect(matchCount).toBeGreaterThanOrEqual(2)
+      } finally {
+        ws.close()
       }
-
-      ws.send(
-        buildSubscribeMsg('wc-0001', [
-          { property: 'kind', values: ['ConfigMap'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['test-wc-*'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-
-      await execCliCmdString(`oc create configmap test-wc-alpha -n ${testNamespace}`)
-      await execCliCmdString(`oc create configmap test-wc-beta -n ${testNamespace}`)
-
-      const received = await waitFor(() => matchCount >= 2)
-      expect(received).toBe(true)
-      expect(matchCount).toBeGreaterThanOrEqual(2)
-      ws.close()
     },
     TEST_TIMEOUT
   )
@@ -89,29 +92,32 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let gotUnexpected = false
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        // Subscribe to 'prefix-wc-*' — 'test-wc-other' should not match.
-        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('test-wc-other')) {
-          gotUnexpected = true
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          // Subscribe to 'prefix-wc-*' — 'test-wc-other' should not match.
+          if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('test-wc-other')) {
+            gotUnexpected = true
+          }
         }
+
+        ws.send(
+          buildSubscribeMsg('wc-0002', [
+            { property: 'kind', values: ['ConfigMap'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['prefix-wc-*'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await execCliCmdString(`oc create configmap test-wc-other -n ${testNamespace}`)
+
+        // Wait long enough to confirm no matching event is delivered.
+        await new Promise((resolve) => setTimeout(resolve, 3000))
+        expect(gotUnexpected).toBe(false)
+      } finally {
+        ws.close()
       }
-
-      ws.send(
-        buildSubscribeMsg('wc-0002', [
-          { property: 'kind', values: ['ConfigMap'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['prefix-wc-*'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString(`oc create configmap test-wc-other -n ${testNamespace}`)
-
-      // Wait long enough to confirm no matching event is delivered.
-      await new Promise((resolve) => setTimeout(resolve, 3000))
-      expect(gotUnexpected).toBe(false)
-      ws.close()
     },
     TEST_TIMEOUT
   )
@@ -122,27 +128,30 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let gotMatch = false
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-suffix-test')) {
-          gotMatch = true
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-suffix-test')) {
+            gotMatch = true
+          }
         }
+
+        ws.send(
+          buildSubscribeMsg('wc-0003', [
+            { property: 'kind', values: ['ConfigMap'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['*-test'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await execCliCmdString(`oc create configmap wc-suffix-test -n ${testNamespace}`)
+
+        const received = await waitFor(() => gotMatch)
+        expect(received).toBe(true)
+      } finally {
+        ws.close()
       }
-
-      ws.send(
-        buildSubscribeMsg('wc-0003', [
-          { property: 'kind', values: ['ConfigMap'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['*-test'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString(`oc create configmap wc-suffix-test -n ${testNamespace}`)
-
-      const received = await waitFor(() => gotMatch)
-      expect(received).toBe(true)
-      ws.close()
     },
     TEST_TIMEOUT
   )
@@ -153,31 +162,34 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let gotMatch = false
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        if (
-          eventData.type === 'next' &&
-          event.data.includes('INSERT') &&
-          event.data.includes('wc-contains-wildcard-cm')
-        ) {
-          gotMatch = true
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          if (
+            eventData.type === 'next' &&
+            event.data.includes('INSERT') &&
+            event.data.includes('wc-contains-wildcard-cm')
+          ) {
+            gotMatch = true
+          }
         }
+
+        ws.send(
+          buildSubscribeMsg('wc-0004', [
+            { property: 'kind', values: ['ConfigMap'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['*wildcard*'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await execCliCmdString(`oc create configmap wc-contains-wildcard-cm -n ${testNamespace}`)
+
+        const received = await waitFor(() => gotMatch)
+        expect(received).toBe(true)
+      } finally {
+        ws.close()
       }
-
-      ws.send(
-        buildSubscribeMsg('wc-0004', [
-          { property: 'kind', values: ['ConfigMap'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['*wildcard*'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString(`oc create configmap wc-contains-wildcard-cm -n ${testNamespace}`)
-
-      const received = await waitFor(() => gotMatch)
-      expect(received).toBe(true)
-      ws.close()
     },
     TEST_TIMEOUT
   )
@@ -188,27 +200,30 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let gotMatch = false
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-kind-test')) {
-          gotMatch = true
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-kind-test')) {
+            gotMatch = true
+          }
         }
+
+        ws.send(
+          buildSubscribeMsg('wc-0005', [
+            { property: 'kind', values: ['ConfigMap*'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['wc-kind-test'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await execCliCmdString(`oc create configmap wc-kind-test -n ${testNamespace}`)
+
+        const received = await waitFor(() => gotMatch)
+        expect(received).toBe(true)
+      } finally {
+        ws.close()
       }
-
-      ws.send(
-        buildSubscribeMsg('wc-0005', [
-          { property: 'kind', values: ['ConfigMap*'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['wc-kind-test'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString(`oc create configmap wc-kind-test -n ${testNamespace}`)
-
-      const received = await waitFor(() => gotMatch)
-      expect(received).toBe(true)
-      ws.close()
     },
     TEST_TIMEOUT
   )
@@ -219,29 +234,32 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       let gotMatch = false
       const ws = await createWebSocket(`${websocketUrl}/searchapi/graphql`, token)
 
-      ws.onmessage = (event) => {
-        const eventData = JSON.parse(event.data)
-        if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-case-test')) {
-          gotMatch = true
+      try {
+        ws.onmessage = (event) => {
+          const eventData = JSON.parse(event.data)
+          if (eventData.type === 'next' && event.data.includes('INSERT') && event.data.includes('wc-case-test')) {
+            gotMatch = true
+          }
         }
+
+        // 'configmap*' (all lowercase) should NOT match kind 'ConfigMap' (mixed case).
+        ws.send(
+          buildSubscribeMsg('wc-0006', [
+            { property: 'kind', values: ['configmap*'] },
+            { property: 'namespace', values: [testNamespace] },
+            { property: 'name', values: ['wc-case-test'] },
+          ])
+        )
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        await execCliCmdString(`oc create configmap wc-case-test -n ${testNamespace}`)
+
+        // Wait to confirm no event arrives for the case-mismatched filter.
+        await new Promise((resolve) => setTimeout(resolve, 3000))
+        expect(gotMatch).toBe(false)
+      } finally {
+        ws.close()
       }
-
-      // 'configmap*' (all lowercase) should NOT match kind 'ConfigMap' (mixed case).
-      ws.send(
-        buildSubscribeMsg('wc-0006', [
-          { property: 'kind', values: ['configmap*'] },
-          { property: 'namespace', values: [testNamespace] },
-          { property: 'name', values: ['wc-case-test'] },
-        ])
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString(`oc create configmap wc-case-test -n ${testNamespace}`)
-
-      // Wait to confirm no event arrives for the case-mismatched filter.
-      await new Promise((resolve) => setTimeout(resolve, 3000))
-      expect(gotMatch).toBe(false)
-      ws.close()
     },
     TEST_TIMEOUT
   )

--- a/tests/api/subscription-wildcard.test.js
+++ b/tests/api/subscription-wildcard.test.js
@@ -11,6 +11,7 @@ const { createWebSocket } = require('../common-lib/websocketHelper')
 
 let token = ''
 let websocketUrl = ''
+const testNamespace = 'automation-subscription-wildcard'
 
 const WATCH_QUERY =
   'subscription watch($input: SearchInput) { watch(input: $input) { uid operation newData oldData timestamp } }'
@@ -42,19 +43,15 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
     token = getKubeadminToken()
     const searchApiRoute = await getSearchApiRoute()
     websocketUrl = searchApiRoute.replace('https://', 'wss://')
-  })
+
+    // Create test namespace
+    await execCliCmdString(`oc create namespace ${testNamespace}`)
+  }, 15000)
 
   afterAll(async () => {
-    await execCliCmdString(`
-      oc delete configmap test-wc-alpha -n default --ignore-not-found
-      oc delete configmap test-wc-beta -n default --ignore-not-found
-      oc delete configmap test-wc-other -n default --ignore-not-found
-      oc delete configmap wc-suffix-test -n default --ignore-not-found
-      oc delete configmap wc-contains-wildcard-cm -n default --ignore-not-found
-      oc delete configmap wc-kind-test -n default --ignore-not-found
-      oc delete configmap wc-case-test -n default --ignore-not-found
-    `)
-  })
+    // Clean up test namespace (deletes all resources within it)
+    await execCliCmdString(`oc delete namespace ${testNamespace} --ignore-not-found=true`)
+  }, 30000)
 
   it(
     'should receive events matching a prefix wildcard filter on name (test-wc-*)',
@@ -76,14 +73,15 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0001', [
           { property: 'kind', values: ['ConfigMap'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['test-wc-*'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
 
-      await execCliCmdString('oc create configmap test-wc-alpha -n default')
-      await execCliCmdString('oc create configmap test-wc-beta -n default')
+      await execCliCmdString(`oc create configmap test-wc-alpha -n ${testNamespace}`)
+      await execCliCmdString(`oc create configmap test-wc-beta -n ${testNamespace}`)
 
       const received = await waitFor(() => matchCount >= 2)
       expect(received).toBe(true)
@@ -110,12 +108,13 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0002', [
           { property: 'kind', values: ['ConfigMap'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['prefix-wc-*'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString('oc create configmap test-wc-other -n default')
+      await execCliCmdString(`oc create configmap test-wc-other -n ${testNamespace}`)
 
       // Wait long enough to confirm no matching event is delivered.
       await new Promise((resolve) => setTimeout(resolve, 3000))
@@ -141,12 +140,13 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0003', [
           { property: 'kind', values: ['ConfigMap'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['*-test'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString('oc create configmap wc-suffix-test -n default')
+      await execCliCmdString(`oc create configmap wc-suffix-test -n ${testNamespace}`)
 
       const received = await waitFor(() => gotMatch)
       expect(received).toBe(true)
@@ -175,12 +175,13 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0004', [
           { property: 'kind', values: ['ConfigMap'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['*wildcard*'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString('oc create configmap wc-contains-wildcard-cm -n default')
+      await execCliCmdString(`oc create configmap wc-contains-wildcard-cm -n ${testNamespace}`)
 
       const received = await waitFor(() => gotMatch)
       expect(received).toBe(true)
@@ -205,12 +206,13 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0005', [
           { property: 'kind', values: ['ConfigMap*'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['wc-kind-test'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString('oc create configmap wc-kind-test -n default')
+      await execCliCmdString(`oc create configmap wc-kind-test -n ${testNamespace}`)
 
       const received = await waitFor(() => gotMatch)
       expect(received).toBe(true)
@@ -236,12 +238,13 @@ describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Sup
       ws.send(
         buildSubscribeMsg('wc-0006', [
           { property: 'kind', values: ['configmap*'] },
+          { property: 'namespace', values: [testNamespace] },
           { property: 'name', values: ['wc-case-test'] },
         ])
       )
 
       await new Promise((resolve) => setTimeout(resolve, 100))
-      await execCliCmdString('oc create configmap wc-case-test -n default')
+      await execCliCmdString(`oc create configmap wc-case-test -n ${testNamespace}`)
 
       // Wait to confirm no event arrives for the case-mismatched filter.
       await new Promise((resolve) => setTimeout(resolve, 3000))

--- a/tests/api/subscription-wildcard.test.js
+++ b/tests/api/subscription-wildcard.test.js
@@ -8,6 +8,7 @@ const squad = require('../../config').get('squadName')
 const { execCliCmdString } = require('../common-lib/cliClient')
 const { getKubeadminToken, getSearchApiRoute } = require('../common-lib/clusterAccess')
 const { createWebSocket } = require('../common-lib/websocketHelper')
+const { waitFor } = require('../common-lib')
 
 let token = ''
 let websocketUrl = ''
@@ -27,15 +28,6 @@ function buildSubscribeMsg(id, filters) {
       operationName: 'watch',
     },
   })
-}
-
-async function waitFor(condition, timeoutMs = 10000, intervalMs = 50) {
-  const start = Date.now()
-  while (!condition()) {
-    if (Date.now() - start > timeoutMs) return false
-    await new Promise((resolve) => setTimeout(resolve, intervalMs))
-  }
-  return true
 }
 
 describe(`[P2][Sev2][${squad}] ACM-27856: Subscription API - Wildcard Filter Support`, () => {

--- a/tests/common-lib/index.js
+++ b/tests/common-lib/index.js
@@ -162,11 +162,12 @@ function shouldUseAPIGroup(kind, resourceList, requiredList = []) {
  */
 async function waitFor(condition, timeoutMs = 10000, intervalMs = 50) {
   const start = Date.now()
-  while (!condition()) {
-    if (Date.now() - start > timeoutMs) return false
+  while (true) {
+    const matched = await Promise.resolve().then(() => condition())
+    if (matched) return true
+    if (Date.now() - start >= timeoutMs) return false
     await new Promise((resolve) => setTimeout(resolve, intervalMs))
   }
-  return true
 }
 
 exports.fetchAPIResourcesWithListWatchMethods = fetchAPIResourcesWithListWatchMethods

--- a/tests/common-lib/index.js
+++ b/tests/common-lib/index.js
@@ -153,8 +153,25 @@ function shouldUseAPIGroup(kind, resourceList, requiredList = []) {
   return _.length > 1 || requiredList.includes(kind)
 }
 
+/**
+ * Waits for a condition to become true within a timeout period.
+ * @param {Function} condition The condition function to evaluate.
+ * @param {number} timeoutMs Maximum time to wait in milliseconds (default: 10000).
+ * @param {number} intervalMs Polling interval in milliseconds (default: 50).
+ * @returns `bool` True if condition was met, false if timeout occurred.
+ */
+async function waitFor(condition, timeoutMs = 10000, intervalMs = 50) {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) return false
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+  return true
+}
+
 exports.fetchAPIResourcesWithListWatchMethods = fetchAPIResourcesWithListWatchMethods
 exports.getClusterList = getClusterList
 exports.getTargetManagedCluster = getTargetManagedCluster
 exports.removeEmptyEntries = removeEmptyEntries
 exports.shouldUseAPIGroup = shouldUseAPIGroup
+exports.waitFor = waitFor


### PR DESCRIPTION
## Summary
- Adds `subscription-wildcard.test.js` with 6 new automated API tests for wildcard (`*`) filter support in streaming subscriptions
- Tests cover prefix (`test-wc-*`), suffix (`*-test`), and contains (`*wildcard*`) wildcard patterns on the `name` property
- Tests cover wildcard on the `kind` property (`ConfigMap*`)
- Validates case-sensitivity (lowercase `configmap*` must NOT match `ConfigMap`)
- Validates negative case: resources not matching the wildcard pattern produce no events

## Related
- Feature PR: https://github.com/stolostron/search-v2-api/pull/704
- Jira: ACM-27856

## Test plan
- [ ] Run `npm run test:api` targeting `subscription-wildcard.test.js` against a live RHACM hub cluster
- [ ] Verify all 6 tests pass with the feature PR deployed
- [ ] Verify negative tests (non-matching wildcard, case mismatch) reliably produce no events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests validating wildcard pattern matching for subscription filters over the Search API WebSocket (prefix, suffix, contains, kind matching, case-sensitivity, and non-matching scenarios).
  * Tests open real WebSocket subscriptions, assert received insertion events for expected resources, include a new polling/wait helper, and perform automated environment setup and teardown to clean up created test resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->