### PR TITLE
Query local cluster name, update explicit timeout for UI login

### DIFF
--- a/start-tests.sh
+++ b/start-tests.sh
@@ -29,7 +29,7 @@ OPTIONS_MANAGED_KUBECONFIG=${OPTIONS_MANAGED_KUBECONFIG:-'/opt/.kube/import-kube
 # Check to see if the test config options file is mounted/available.
 if [[ -f $OPTIONS_FILE ]]; then
   log_color "yellow" "Using test config from: $OPTIONS_FILE\n"
-  export ACM_NAMESPACE=`yq e '.options.acmNamespace' $OPTIONS_FILE`
+  export ACM_NAMESPACE=`yq e '.options.hub.acmNamespace' $OPTIONS_FILE`
   export OPTIONS_HUB_BASEDOMAIN=`yq e '.options.hub.baseDomain' $OPTIONS_FILE`
   export OPTIONS_HUB_KUBECONTEXT=`yq e '.options.hub.kubecontext' $OPTIONS_FILE`
   export OPTIONS_HUB_OC_IDP=`yq e '.options.identityProvider' $OPTIONS_FILE`
@@ -40,7 +40,7 @@ if [[ -f $OPTIONS_FILE ]]; then
   export OPTIONS_MANAGED_KUBECONFIG=`yq e '.options.clusters[0].kubeconfig' $OPTIONS_FILE`
 elif [[ -f $USER_OPTIONS_FILE ]]; then
   log_color "yellow" "Using test config from: $USER_OPTIONS_FILE\n"
-  export ACM_NAMESPACE=`yq e '.options.acmNamespace' $USER_OPTIONS_FILE`
+  export ACM_NAMESPACE=`yq e '.options.hub.acmNamespace' $USER_OPTIONS_FILE`
   export OPTIONS_HUB_BASEDOMAIN=`yq e '.options.hub.baseDomain' $USER_OPTIONS_FILE`
   export OPTIONS_HUB_KUBECONTEXT=`yq e '.options.hub.kubecontext' $USER_OPTIONS_FILE`
   export OPTIONS_HUB_OC_IDP=`yq e '.options.identityProvider' $USER_OPTIONS_FILE`
@@ -170,10 +170,18 @@ log_color "green" "Testing with ACM Version": "$CYPRESS_ACM_VERSION\n"
 installNamespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 
 # Search for managed clusters.
-MANAGED_CLUSTERS=($(oc get managedclusters -o custom-columns='name:.metadata.name' --no-headers))
+MANAGED_CLUSTERS=($(oc get managedclusters -l '!local-cluster' -o custom-columns='name:.metadata.name' --no-headers))
+
+# Search for local cluster.
+LOCAL_CLUSTER=$(oc get managedclusters -l 'local-cluster' -o jsonpath='{.items[0].metadata.name}' | tr -d '\n')
+if [[ -z $LOCAL_CLUSTER ]]; then
+  log_color "red" "Unable to resolve the local managed cluster name from the hub cluster."
+  exit 1
+fi
+export CYPRESS_LOCAL_CLUSTER="$LOCAL_CLUSTER"
 
 # Check to see if there are any managed cluster available.
-if [[ ${#MANAGED_CLUSTERS[@]} == "1" && ${MANAGED_CLUSTERS[0]} =~ "local-cluster" ]]; then
+if [[ ${#MANAGED_CLUSTERS[@]} -lt 1 ]]; then
   echo -e "No managable clusters detected for the hub cluster: $CYPRESS_OPTIONS_HUB_BASEDOMAIN.\n"
   export SKIP_MANAGED_CLUSTER_TEST=true
 else

--- a/tests/api/common.test.js
+++ b/tests/api/common.test.js
@@ -3,7 +3,7 @@
 jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 
 const squad = require('../../config').get('squadName')
-const { getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterAccess')
+const { getSearchApiRoute, getKubeadminToken, getLocalClusterName } = require('../common-lib/clusterAccess')
 const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient')
 
 const _ = require('lodash')
@@ -51,7 +51,7 @@ describe('RHACM4K-1696: Search API - Verify search result with common filter and
     var query = searchQueryBuilder({
       filters: [
         { property: 'kind', values: ['Pod'] },
-        { property: 'cluster', values: ['local-cluster'] },
+        { property: 'cluster', values: [getLocalClusterName()] },
         { property: 'status', values: ['Running'] },
       ],
     })

--- a/tests/api/data-validation.test.js
+++ b/tests/api/data-validation.test.js
@@ -3,7 +3,12 @@
 jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 
 const squad = require('../../config').get('squadName')
-const { getKubeConfig, getKubeadminToken, getSearchApiRoute } = require('../common-lib/clusterAccess')
+const {
+  getKubeConfig,
+  getKubeadminToken,
+  getSearchApiRoute,
+  getLocalClusterName,
+} = require('../common-lib/clusterAccess')
 const { fetchAPIResourcesWithListWatchMethods, getClusterList, shouldUseAPIGroup } = require('../common-lib/index')
 const { ValidateSearchData, validationTimeout } = require('../common-lib/validateSearchData')
 
@@ -44,7 +49,7 @@ describe(`[P2][Sev2][${squad}] Search API: Validate data in index`, () => {
         // This test checks the validation logic in case that a CRD gets removed.
         test(
           `check for a CRD that doesn't exist [kind:MissingCRD]`,
-          async () => ValidateSearchData({ user, kind: 'MissingCRD', cluster: { name: 'local-cluster' } }),
+          async () => ValidateSearchData({ user, kind: 'MissingCRD', cluster: { name: getLocalClusterName() } }),
           validationTimeout
         )
 

--- a/tests/api/filter.test.js
+++ b/tests/api/filter.test.js
@@ -5,7 +5,7 @@ jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 const { execSync } = require('child_process')
 
 const squad = require('../../config').get('squadName')
-const { getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterAccess')
+const { getSearchApiRoute, getKubeadminToken, getLocalClusterName } = require('../common-lib/clusterAccess')
 // const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient')
 
 describe('RHACM4K-1709: Search - Search using filters', () => {
@@ -67,7 +67,7 @@ describe('RHACM4K-1709: Search - Search using filters', () => {
       ],
     },
     { filters: [{ property: 'startedAt', values: ['month'] }] },
-    { filters: [{ property: 'cluster', values: ['local-cluster'] }] },
+    { filters: [{ property: 'cluster', values: [getLocalClusterName()] }] },
     { filters: [{ property: 'port', values: ['8443/TCP'] }] },
     { filters: [{ property: 'type', values: ['ClusterIP'] }] },
     // {

--- a/tests/api/managed.test.js
+++ b/tests/api/managed.test.js
@@ -3,7 +3,7 @@
 jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 
 const squad = require('../../config').get('squadName')
-const { getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterAccess')
+const { getSearchApiRoute, getKubeadminToken, getLocalClusterName } = require('../common-lib/clusterAccess')
 const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient')
 const _ = require('lodash')
 
@@ -19,7 +19,7 @@ describe('RHACM4K-1695: Search - verify managed cluster info in the search page'
   test(`[P1][Sev1][${squad}] Search - verify managed cluster info in the search page.`, async () => {
     var query = searchQueryBuilder({
       filters: [
-        { property: 'name', values: ['!local-cluster'] },
+        { property: 'name', values: ['!' + getLocalClusterName()] },
         { property: 'ManagedClusterJoined', values: ['True'] },
       ],
     })
@@ -29,7 +29,7 @@ describe('RHACM4K-1695: Search - verify managed cluster info in the search page'
 
       query = searchQueryBuilder({
         filters: [
-          { property: 'cluster', values: ['!local-cluster'] },
+          { property: 'cluster', values: ['!' + getLocalClusterName()] },
           { property: 'kind', values: ['Pod'] },
           { property: 'namespace', values: ['open-cluster-management-agent'] },
         ],

--- a/tests/api/pagination.test.js
+++ b/tests/api/pagination.test.js
@@ -6,7 +6,7 @@
 jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 
 const squad = require('../../config').get('squadName')
-const { getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterAccess')
+const { getSearchApiRoute, getKubeadminToken, getLocalClusterName } = require('../common-lib/clusterAccess')
 const { execCliCmdString } = require('../common-lib/cliClient')
 const {
   resolveSearchCount,
@@ -55,7 +55,7 @@ describe(`[P3][Sev3][${squad}] Search API - Verify pagination functionality`, ()
   const baseFilters = [
     { property: 'kind', values: ['ConfigMap'] },
     { property: 'namespace', values: [ns] },
-    { property: 'cluster', values: ['local-cluster'] },
+    { property: 'cluster', values: [getLocalClusterName()] },
   ]
 
   test('should return correct total count', async () => {

--- a/tests/api/search.test.js
+++ b/tests/api/search.test.js
@@ -5,7 +5,12 @@ jest.retryTimes(global.retry, { logErrorsBeforeRetry: true })
 const { execSync } = require('child_process')
 
 const squad = require('../../config').get('squadName')
-const { getKubeConfig, getSearchApiRoute, getKubeadminToken } = require('../common-lib/clusterAccess')
+const {
+  getKubeConfig,
+  getSearchApiRoute,
+  getKubeadminToken,
+  getLocalClusterName,
+} = require('../common-lib/clusterAccess')
 const { searchQueryBuilder, sendRequest } = require('../common-lib/searchClient')
 
 describe('RHACM4K-913: Search API - Verify search results with different queries', () => {
@@ -14,6 +19,12 @@ describe('RHACM4K-913: Search API - Verify search results with different queries
 
   // Get managed cluster
   var import_kubeconfig = kubeconfigs.find((k) => k.includes('import'))
+
+  // Get ACM namespace
+  const acmNamespace = execSync("oc get mch -A -o jsonpath='{.items[0].metadata.namespace}'").toString().trim()
+  if (!acmNamespace) {
+    throw new Error('Unable to resolve the ACM namespace')
+  }
 
   beforeAll(async () => {
     // Log in and get access token
@@ -33,32 +44,30 @@ describe('RHACM4K-913: Search API - Verify search results with different queries
     }
   })
 
-  // Skipping this test because it fails intermittently, which creates unreliable results.
-  test.skip(`[P3][Sev3][${squad}] should have expected count of pods in ocm on hub cluster.`, async () => {
+  test(`[P3][Sev3][${squad}] should have expected count of pods in ocm on hub cluster.`, async () => {
     var query = searchQueryBuilder({
       filters: [
         { property: 'kind', values: ['Pod'] },
-        { property: 'namespace', values: ['open-cluster-management'] },
+        { property: 'namespace', values: [acmNamespace] },
         { property: 'status', values: ['Running'] },
-        { property: 'cluster', values: ['local-cluster'] },
+        { property: 'cluster', values: [getLocalClusterName()] },
       ],
     })
     const [searchRes, cliRes] = await Promise.all([
       sendRequest(query, token),
-      execSync('oc get pods -n open-cluster-management --field-selector=status.phase==Running --no-headers | wc -l'),
+      execSync(`oc get pods -n ${acmNamespace} --field-selector=status.phase==Running --no-headers | wc -l`),
     ])
     const pods = searchRes.body.data.searchResult[0].items
     expect(pods.length.toString()).toEqual(cliRes.toString().trim())
   }, 10000)
 
-  // Skipping this test because it fails intermittently, which creates unreliable results.
-  test.skip(`[P3][Sev3][${squad}] should have expected count of pods in ocm-agent on hub cluster.`, async () => {
+  test(`[P3][Sev3][${squad}] should have expected count of pods in ocm-agent on hub cluster.`, async () => {
     var query = searchQueryBuilder({
       filters: [
         { property: 'kind', values: ['Pod'] },
         { property: 'namespace', values: ['open-cluster-management-agent'] },
         { property: 'status', values: ['Running'] },
-        { property: 'cluster', values: ['local-cluster'] },
+        { property: 'cluster', values: [getLocalClusterName()] },
       ],
     })
     const [searchRes, cliRes] = await Promise.all([
@@ -94,14 +103,13 @@ describe('RHACM4K-913: Search API - Verify search results with different queries
     }
   }, 10000)
 
-  // Skipping this test because it fails intermittently, which creates unreliable results.
-  test.skip(`[P3][Sev3][${squad}] should have expected count of pods in ocm-agent-addon on hub cluster.`, async () => {
+  test(`[P3][Sev3][${squad}] should have expected count of pods in ocm-agent-addon on hub cluster.`, async () => {
     var query = searchQueryBuilder({
       filters: [
         { property: 'kind', values: ['Pod'] },
         { property: 'namespace', values: ['open-cluster-management-agent-addon'] },
         { property: 'status', values: ['Running'] },
-        { property: 'cluster', values: ['local-cluster'] },
+        { property: 'cluster', values: [getLocalClusterName()] },
       ],
     })
     const [searchRes, cliRes] = await Promise.all([

--- a/tests/common-lib/cliClient.js
+++ b/tests/common-lib/cliClient.js
@@ -1,6 +1,7 @@
 // Copyright Contributors to the Open Cluster Management project
 
 const { execSync } = require('child_process')
+const { getLocalClusterName } = require('./clusterAccess')
 
 /**
  * Execute a string of commands separated by \n.
@@ -35,7 +36,7 @@ function getResourcesFromOC({
   kind,
   apigroup,
   namespace = '--all-namespaces',
-  cluster = { type: 'hub', name: 'local-cluster' },
+  cluster = { type: 'hub', name: getLocalClusterName() },
 }) {
   if (!kind) {
     console.error('Error in test code, kind is required when calling getResourcesFromOC(). Received:', kind)

--- a/tests/common-lib/clusterAccess.js
+++ b/tests/common-lib/clusterAccess.js
@@ -1,6 +1,6 @@
 // Copyright Contributors to the Open Cluster Management project
 
-const config = require('../../config')
+// const config = require('../../config')
 const { sleep } = require('./sleep')
 const { execSync } = require('child_process')
 const fs = require('fs')
@@ -114,9 +114,26 @@ async function getUserContext({ usr, ns }) {
   }
 }
 
+/**
+ * Get the local cluster name for the target cluster environment.
+ * @returns {string} The local cluster name.
+ */
+let localClusterName
+function getLocalClusterName() {
+  if (localClusterName) {
+    return localClusterName
+  }
+  localClusterName = execSync("oc get managedcluster -l local-cluster -o jsonpath='{.items[0].metadata.name}'")
+    .toString()
+    .trim()
+  if (!localClusterName) throw new Error('Unable to resolve the local cluster name')
+  return localClusterName
+}
+
 exports.deleteResource = deleteResource
 exports.getKubeConfig = getKubeConfig
 exports.getUserContext = getUserContext
 exports.getResource = getResource
 exports.getSearchApiRoute = getSearchApiRoute
 exports.getKubeadminToken = getKubeadminToken
+exports.getLocalClusterName = getLocalClusterName

--- a/tests/common-lib/index.js
+++ b/tests/common-lib/index.js
@@ -1,6 +1,7 @@
 // Copyright Contributors to the Open Cluster Management project
 
 const { execSync } = require('child_process')
+const { getLocalClusterName } = require('./clusterAccess')
 
 /**
  * Fetches all namespaced resources that has methods list and watch.
@@ -48,7 +49,7 @@ function fetchAPIResourcesWithListWatchMethods() {
 function getClusterList(kubeconfigs = []) {
   const clusters = [
     {
-      name: 'local-cluster',
+      name: getLocalClusterName(),
       skip: false,
       type: 'hub',
     },
@@ -108,7 +109,8 @@ function getTargetManagedCluster() {
       )
     }
 
-    if (managedClusters.length === 1 && managedClusters.find((c) => c.includes('local-cluster'))) {
+    // if (managedClusters.length === 1 && managedClusters.find((c) => c.includes('local-cluster'))) {
+    if (managedClusters.length === 1 && managedClusters.find((c) => c == getLocalClusterName())) {
       console.info(
         `Managed cluster list only contains one managed cluster: ${managedClusters}. Proceeding to test only the local-cluster.`
       )
@@ -121,7 +123,7 @@ function getTargetManagedCluster() {
     }
 
     if (targetCluster === undefined) {
-      targetCluster = managedClusters.find((c) => !c.includes('local-cluster'))
+      targetCluster = managedClusters.find((c) => !c.includes(getLocalClusterName()))
     }
 
     console.info(`Preparing to test with managed cluster: ${targetCluster}`)

--- a/tests/common-lib/searchClient.js
+++ b/tests/common-lib/searchClient.js
@@ -6,6 +6,7 @@
 const { fail } = require('assert')
 const request = require('supertest')
 const lodash = require('lodash')
+const { getLocalClusterName } = require('./clusterAccess')
 
 /**
  * Query the Search API using the given filters.
@@ -20,7 +21,7 @@ async function getResourcesFromSearch({
   kind,
   apigroup,
   namespace = '--all-namespaces',
-  cluster = { type: 'hub', name: 'local-cluster' },
+  cluster = { type: 'hub', name: getLocalClusterName() },
 }) {
   // Build the search api query.
   const filters = formatFilters(kind, apigroup, namespace, cluster)
@@ -131,7 +132,12 @@ function sendRequest(query, token, options = {}) {
  * @param {Object} cluster The cluster to filter the resources against.
  * @returns {[filter]} Formatted array of object filters.
  */
-function formatFilters(kind, group, namespace = '--all-namespaces', cluster = { type: 'hub', name: 'local-cluster' }) {
+function formatFilters(
+  kind,
+  group,
+  namespace = '--all-namespaces',
+  cluster = { type: 'hub', name: getLocalClusterName() }
+) {
   const filter = []
 
   // Add namespace filter

--- a/tests/common-lib/validateSearchData.js
+++ b/tests/common-lib/validateSearchData.js
@@ -3,6 +3,7 @@
 const { getResourcesFromSearch } = require('./searchClient')
 const { getResourcesFromOC } = require('./cliClient')
 const { sleep } = require('./sleep')
+const { getLocalClusterName } = require('./clusterAccess')
 
 /**
  * Common function to validate that the data in search matches
@@ -16,7 +17,7 @@ async function ValidateSearchData({
   user,
   kind,
   apigroup = '',
-  cluster = { type: 'hub', name: 'local-cluster' },
+  cluster = { type: 'hub', name: getLocalClusterName() },
   namespace = '--all-namespaces',
   retries = 12, // Default to 12 because some tests create namespaces and RBAC cache takes up to 60 seconds to update.
   retryWait = 5000,

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -55,7 +55,8 @@ Cypress.Commands.add('visitAndLogin', (URL, OPTIONS_HUB_USER, OPTIONS_HUB_PASSWO
           cy.get('#inputUsername').click().focused().type(user)
           cy.get('#inputPassword').click().focused().type(password)
           cy.get('button[type="submit"]').click()
-          cy.get(pf.page.main).should('exist')
+          cy.url().should('include', '/multicloud')
+          cy.get(pf.page.main, { timeout: 3 * 60 * 1000 }).should('exist')
         }
       })
     } else {

--- a/tests/cypress/tests/overview.spec.js
+++ b/tests/cypress/tests/overview.spec.js
@@ -6,7 +6,7 @@
 import { squad, tags } from '../config'
 import { overviewPage } from '../views/overview'
 
-describe('RHACM4K-1419: Overview page', { tags: tags.env }, function () {
+describe('RHACM4K-1419: Overview page', { tags: tags.env, defaultCommandTimeout: 30000 }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
     cy.visitAndLogin('/multicloud/home/overview')

--- a/tests/cypress/tests/resourceDetailsPage.spec.js
+++ b/tests/cypress/tests/resourceDetailsPage.spec.js
@@ -12,7 +12,7 @@ const clusterMode = {
   label: 'Local',
   namespace: Cypress.env('ACM_NAMESPACE'),
   skip: false,
-  valueFn: () => cy.wrap('local-cluster'),
+  valueFn: () => cy.wrap(Cypress.env('LOCAL_CLUSTER')),
 }
 
 describe(`RHACM4K-57211 - Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {

--- a/tests/cypress/tests/saved-searches.spec.js
+++ b/tests/cypress/tests/saved-searches.spec.js
@@ -8,6 +8,7 @@ import { savedSearches } from '../views/savedSearches'
 import { searchBar, searchPage } from '../views/search'
 
 const namespace = Cypress.env('ACM_NAMESPACE')
+const localClusterName = Cypress.env('LOCAL_CLUSTER')
 
 const queryDefaultNamespaceName = `${namespace}-default`
 const queryDefaultNamespaceDesc = `This is searching that the cluster should have ${namespace} namespace.`
@@ -15,7 +16,7 @@ const queryDefaultNamespaceDesc = `This is searching that the cluster should hav
 const queryEditNamespaceName = `[E2E] ${namespace}-edit`
 const queryEditNamespaceDesc = `[Created by Search E2E automation] This is searching that the cluster should have ${namespace} namespace.`
 
-describe('RHACM4K-412 - Saved searches', { tags: tags.env }, function () {
+describe('RHACM4K-412 - Saved searches', { tags: tags.env, defaultCommandTimeout: 30000 }, function () {
   beforeEach(function () {
     // Log into the cluster ACM console.
     cy.visitAndLogin('/multicloud/search')
@@ -30,7 +31,7 @@ describe('RHACM4K-412 - Saved searches', { tags: tags.env }, function () {
 
     it(`[P3][Sev3][${squad}] should save current search`, function () {
       savedSearches.saveClusterNamespaceSearch(
-        'local-cluster',
+        localClusterName,
         namespace,
         queryDefaultNamespaceName,
         queryDefaultNamespaceDesc

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -11,7 +11,7 @@ const clusterMode = {
   label: 'Local',
   namespace: Cypress.env('ACM_NAMESPACE'),
   skip: false,
-  valueFn: () => cy.wrap('local-cluster'),
+  valueFn: () => cy.wrap(Cypress.env('LOCAL_CLUSTER')),
 }
 
 describe(`RHACM4K-57212 - Search in ${clusterMode.label} Cluster`, { tags: tags.env }, function () {

--- a/tests/cypress/tests/suggested-searches.spec.js
+++ b/tests/cypress/tests/suggested-searches.spec.js
@@ -7,29 +7,33 @@ import { squad, tags } from '../config'
 import { searchBar } from '../views/search'
 import { suggestedSearches } from '../views/suggestedSearches'
 
-describe('RHACM4K-411: Verify the suggested search templates', { tags: tags.env }, function () {
-  beforeEach(function () {
-    // Log into the cluster ACM console.
-    cy.visitAndLogin('/multicloud/search')
-  })
-
-  context('Console-Search suggested searches', { tags: tags.modes }, function () {
-    it(`[P3][Sev3][${squad}] should see the workloads template & search tag in search items`, function () {
-      suggestedSearches.whenSelectCardWithTitle('Workloads')
-      searchBar.shouldContainTag('kind:DaemonSet,Deployment,Job,StatefulSet,ReplicaSet')
+describe(
+  'RHACM4K-411: Verify the suggested search templates',
+  { tags: tags.env, defaultCommandTimeout: 30000 },
+  function () {
+    beforeEach(function () {
+      // Log into the cluster ACM console.
+      cy.visitAndLogin('/multicloud/search')
     })
 
-    it(`[P3][Sev3][${squad}] should see the unhealthy pods template & search tag in search items`, function () {
-      suggestedSearches.whenSelectCardWithTitle('Unhealthy pods')
-      searchBar.shouldContainTag('kind:Pod')
-      searchBar.shouldContainTag(
-        'status:Pending,Error,Failed,Terminating,ImagePullBackOff,CrashLoopBackOff,RunContainerError,ContainerCreating'
-      )
-    })
+    context('Console-Search suggested searches', { tags: tags.modes }, function () {
+      it(`[P3][Sev3][${squad}] should see the workloads template & search tag in search items`, function () {
+        suggestedSearches.whenSelectCardWithTitle('Workloads')
+        searchBar.shouldContainTag('kind:DaemonSet,Deployment,Job,StatefulSet,ReplicaSet')
+      })
 
-    it(`[P3][Sev3][${squad}] should see the created last hour template & search tag in search items`, function () {
-      suggestedSearches.whenSelectCardWithTitle('Created last hour')
-      searchBar.shouldContainTag('created:hour')
+      it(`[P3][Sev3][${squad}] should see the unhealthy pods template & search tag in search items`, function () {
+        suggestedSearches.whenSelectCardWithTitle('Unhealthy pods')
+        searchBar.shouldContainTag('kind:Pod')
+        searchBar.shouldContainTag(
+          'status:Pending,Error,Failed,Terminating,ImagePullBackOff,CrashLoopBackOff,RunContainerError,ContainerCreating'
+        )
+      })
+
+      it(`[P3][Sev3][${squad}] should see the created last hour template & search tag in search items`, function () {
+        suggestedSearches.whenSelectCardWithTitle('Created last hour')
+        searchBar.shouldContainTag('created:hour')
+      })
     })
-  })
-})
+  }
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login reliability: extended page-container timeout to 3 minutes and added URL path verification.
  * Refined cluster discovery to exclude the local cluster from managed-cluster lists and require explicit local-cluster resolution.

* **Tests**
  * Tests now resolve the local cluster and hub namespace at runtime instead of using hardcoded names.
  * Several hub-cluster checks were reactivated; some test suites have increased command timeouts.

* **Chores**
  * Test startup exports the resolved local cluster value for Cypress tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->