### PR TITLE
slight wait before skeleton assertion

### DIFF
--- a/tests/cypress/views/search.js
+++ b/tests/cypress/views/search.js
@@ -70,6 +70,7 @@ export const searchPage = {
    * Verify that the search page should contain no skeleton placeholder elements.
    */
   shouldFindNoSkeleton: () => {
+    cy.wait(500) // wait 500 ms for empty state / skeleton to disappear before we assert they don't exist in case of slow console
     cy.get(pf.emptyState.icon).should('not.exist')
     cy.get(pf.skeleton.base).should('not.exist')
   },


### PR DESCRIPTION
Saved search tests failed in [jenkins run](https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_tests/289/consoleFull) due to possibly not waiting for results to actually appear
```
  1) RHACM4K-412 - Saved searches
       Console-Search saved searches
         [P3][Sev3][observability-usa] should verify that the namespace is available:
     AssertionError: Timed out retrying after 20000ms: Expected <div.pf-v6-c-empty-state__icon> not to exist in the DOM, but it was continuously found.
      at Object.shouldFindNoSkeleton (webpack://search-e2e-test/./tests/cypress/views/search.js:73:31)
      at Object.whenRunSearchQuery (webpack://search-e2e-test/./tests/cypress/views/search.js:283:15)
      at Context.eval (webpack://search-e2e-test/./tests/cypress/tests/saved-searches.spec.js:27:16)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for search functionality by adding a delay to prevent flakiness during skeleton UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->