### PR TITLE
ACM-35292 ACM-35293 ACM-35294 - skip consistently failing UI tests

### DIFF
--- a/tests/cypress/tests/overview.spec.js
+++ b/tests/cypress/tests/overview.spec.js
@@ -21,7 +21,7 @@ describe('RHACM4K-1419: Overview page', { tags: tags.env, defaultCommandTimeout:
       overviewPage.shouldHaveSummarySection()
     })
 
-    it(`[P2][Sev2][${squad}] should have insights section`, function () {
+    it.skip(`[P2][Sev2][${squad}] should have insights section`, function () {
       overviewPage.shouldHaveInsightsSection()
     })
 

--- a/tests/cypress/tests/resourceDetailsPage.spec.js
+++ b/tests/cypress/tests/resourceDetailsPage.spec.js
@@ -31,7 +31,7 @@ describe(`RHACM4K-57211 - Search in ${clusterMode.label} Cluster`, { tags: tags.
       searchPage.shouldFindNamespaceInCluster(clusterMode.namespace, this.clusterName)
     })
 
-    it(`[P2][Sev2][${squad}] should see pod logs`, function () {
+    it.skip(`[P2][Sev2][${squad}] should see pod logs`, function () {
       searchBar.whenFilterByKind('Pod')
       searchBar.whenRunSearchQuery()
       searchBar.whenUsePagination(50)

--- a/tests/cypress/tests/saved-searches.spec.js
+++ b/tests/cypress/tests/saved-searches.spec.js
@@ -23,13 +23,13 @@ describe('RHACM4K-412 - Saved searches', { tags: tags.env, defaultCommandTimeout
   })
 
   context('Console-Search saved searches', { tags: tags.modes }, function () {
-    it(`[P3][Sev3][${squad}] should verify that the namespace is available`, function () {
+    it.skip(`[P3][Sev3][${squad}] should verify that the namespace is available`, function () {
       searchBar.whenFilterByNamespace(namespace)
       searchBar.whenRunSearchQuery()
       searchPage.shouldLoadResults()
     })
 
-    it(`[P3][Sev3][${squad}] should save current search`, function () {
+    it.skip(`[P3][Sev3][${squad}] should save current search`, function () {
       savedSearches.saveClusterNamespaceSearch(
         localClusterName,
         namespace,
@@ -38,23 +38,23 @@ describe('RHACM4K-412 - Saved searches', { tags: tags.env, defaultCommandTimeout
       )
     })
 
-    it(`[P3][Sev3][${squad}] should find the saved search`, function () {
+    it.skip(`[P3][Sev3][${squad}] should find the saved search`, function () {
       savedSearches.getSavedSearch(queryDefaultNamespaceName)
     })
 
-    it(`[P3][Sev3][${squad}] should edit the saved searches`, function () {
+    it.skip(`[P3][Sev3][${squad}] should edit the saved searches`, function () {
       savedSearches.editSavedSearch(namespace, queryEditNamespaceName, queryEditNamespaceDesc)
     })
 
-    it(`[P3][Sev3][${squad}] should revert back the edited saved searches`, function () {
+    it.skip(`[P3][Sev3][${squad}] should revert back the edited saved searches`, function () {
       savedSearches.editSavedSearch(queryEditNamespaceName, queryDefaultNamespaceName, queryDefaultNamespaceDesc)
     })
 
-    it(`[P3][Sev3][${squad}] should share the saved searches`, function () {
+    it.skip(`[P3][Sev3][${squad}] should share the saved searches`, function () {
       savedSearches.shareSavedSearch(queryDefaultNamespaceName)
     })
 
-    it(`[P3][Sev3][${squad}] should delete the saved searches ${queryDefaultNamespaceName}`, function () {
+    it.skip(`[P3][Sev3][${squad}] should delete the saved searches ${queryDefaultNamespaceName}`, function () {
       savedSearches.whenDeleteSavedSearch(queryDefaultNamespaceName)
     })
   })

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -39,7 +39,7 @@ describe(`RHACM4K-57212 - Search in ${clusterMode.label} Cluster`, { tags: tags.
       searchPage.shouldFindNamespaceInCluster(clusterMode.namespace, this.clusterName)
     })
 
-    it(`[P2][Sev2][${squad}] should work kind filter for Deployment`, function () {
+    it.skip(`[P2][Sev2][${squad}] should work kind filter for Deployment`, function () {
       searchBar.whenFilterByKind('Deployment')
       searchBar.whenRunSearchQuery()
       searchBar.whenUsePagination(50)

--- a/tests/cypress/tests/search.spec.js
+++ b/tests/cypress/tests/search.spec.js
@@ -46,7 +46,7 @@ describe(`RHACM4K-57212 - Search in ${clusterMode.label} Cluster`, { tags: tags.
       searchPage.shouldFindResourceDetailItem('Deployment', clusterMode.deployment, clusterMode.namespace)
     })
 
-    it(`[P3][Sev3][${squad}] should have the expected relationships`, function () {
+    it.skip(`[P3][Sev3][${squad}] should have the expected relationships`, function () {
       searchBar.whenRunSearchQuery()
       searchPage.whenExpandRelationshipTiles()
       searchPage.shouldFindRelationshipTile('Cluster')


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-35292
https://redhat.atlassian.net/browse/ACM-35293
https://redhat.atlassian.net/browse/ACM-35294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage by skipping the Pod resource details “pod logs” verification.
  * Skipped multiple Cypress scenarios in Saved searches (namespace availability, saving/finding/editing/reverting, sharing, and deleting) while keeping existing setup in place.
  * Skipped the “kind filter for Deployment” Cypress test in the search suite.
  * Skipped the “insights” section validation on the console Overview page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->