### PR TITLE
Add pre-stage to enable configurable collection before Search E2E tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,33 @@ pipeline {
                 '''
             }
         }
+        stage('Enable Configurable Collection') {
+            steps {
+                sh """
+                    oc login --insecure-skip-tls-verify -u ${params.OCP_HUB_CLUSTER_USER} -p ${params.OCP_HUB_CLUSTER_PASSWORD} ${params.OCP_HUB_CLUSTER_API_URL}
+                    oc patch search search-v2-operator -n ${params.ACM_NAMESPACE} --type merge -p '{"spec":{"deployments":{"collector":{"envVar":[{"name":"FEATURE_CONFIGURABLE_COLLECTION","value":"true"}]}}}}'
+
+                    echo "Waiting for collector pod to restart with feature flag enabled..."
+                    TIMEOUT=120
+                    ELAPSED=0
+                    while [ \$ELAPSED -lt \$TIMEOUT ]; do
+                        ENV_VAL=\$(oc get pod -n ${params.ACM_NAMESPACE} -l name=search-collector -o jsonpath='{.items[*].spec.containers[0].env[?(@.name=="FEATURE_CONFIGURABLE_COLLECTION")].value}' 2>/dev/null || true)
+                        READY=\$(oc get pod -n ${params.ACM_NAMESPACE} -l name=search-collector -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+                        if [ "\$ENV_VAL" = "true" ] && [ "\$READY" = "True" ]; then
+                            echo "Collector is ready with FEATURE_CONFIGURABLE_COLLECTION enabled."
+                            break
+                        fi
+                        echo "  Still waiting... (\$ELAPSED/\$TIMEOUT seconds)"
+                        sleep 5
+                        ELAPSED=\$((ELAPSED + 5))
+                    done
+                    if [ \$ELAPSED -ge \$TIMEOUT ]; then
+                        echo "ERROR: Timed out waiting for collector to restart with feature flag."
+                        exit 1
+                    fi
+                """
+            }
+        }
         stage('Search Tests') {
             steps {
                 catchError(stageResult: 'UNSTABLE',  buildResult: null) { 


### PR DESCRIPTION
### Summary

Adding a Jenkins pre-stage that enables the `FEATURE_CONFIGURABLE_COLLECTION` feature flag before the Search E2E test suite starts.

The pre-stage:
- Patches the Search CR to enable `FEATURE_CONFIGURABLE_COLLECTION`
- Waits for the Search collector rollout to complete
- Verifies the collector is Ready before executing the Search test stage

### Description

Configurable Collection currently requires the feature flag to be enabled, which triggers a collector restart.

By performing this setup before the Search tests begin, the collector rollout completes before any tests execute, avoiding interference during the test run.

This also provides a dedicated setup stage that can be extended in the future as additional Search-specific environment preparation is needed.

### Testing

- Verified locally against a test cluster.
- Verified in the Search Jenkins job that the collector rollout completes successfully before the Search test stage begins.
https://jenkins-csb-rhacm-tests.dno.corp.redhat.com/job/CI-Jobs/job/search_tests/332/execution/node/34/log/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled configurable collection during deployment.
  * Added readiness checks to confirm the feature is active before continuing.
  * Deployment now reports progress and stops with an error if activation takes too long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->