### PR TITLE
ACM-37751 - automation networkpolicy

### DIFF
--- a/tests/api/globalSetup.js
+++ b/tests/api/globalSetup.js
@@ -1,9 +1,37 @@
 // Copyright Contributors to the Open Cluster Management project
 
+const { execSync } = require('child_process')
 const { getSearchApiRoute } = require('../common-lib/clusterAccess')
 
 module.exports = async () => {
   console.log('Start globalSetup.')
+
+  const namespace = execSync(`oc get mch -A -o jsonpath='{.items[0].metadata.namespace}'`).toString()
+
+  // Allow Route traffic through the search-api NetworkPolicy.
+  execSync(`cat <<'EOF' | oc apply -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: search-api-e2e-route-access
+  namespace: ${namespace}
+spec:
+  podSelector:
+    matchLabels:
+      name: search-api
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-ingress
+    ports:
+    - port: 4010
+      protocol: TCP
+EOF`)
+  console.log('Created NetworkPolicy search-api-e2e-route-access.')
+
   await getSearchApiRoute()
   console.log('Done globalSetup.')
 }

--- a/tests/api/globalTeardown.js
+++ b/tests/api/globalTeardown.js
@@ -4,6 +4,8 @@ const { execSync } = require('child_process')
 
 module.exports = () => {
   const namespace = execSync(`oc get mch -A -o jsonpath='{.items[0].metadata.namespace}'`).toString()
+  execSync(`oc delete networkpolicy search-api-e2e-route-access -n ${namespace} --ignore-not-found`)
+  console.log('globalTeardown.js - Deleted NetworkPolicy search-api-e2e-route-access.')
   execSync(`oc delete route search-api-automation -n ${namespace} --ignore-not-found`)
   console.log('globalTeardown.js - Deleted route search-api-automation.')
 }


### PR DESCRIPTION
Unbreak API access that will be introduced by https://github.com/stolostron/search-v2-operator/pull/761 by setting up an additional policy, followed by deleting if once automation completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated API test setup by configuring required network access before tests run.
  * Added automatic cleanup of temporary network access rules after test execution.
  * Enhanced test reliability when accessing the Search API through platform-managed routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->